### PR TITLE
Made it so none of configs params can be None.

### DIFF
--- a/pytoil/api.py
+++ b/pytoil/api.py
@@ -10,8 +10,6 @@ import urllib.error
 import urllib.request
 from typing import Dict, List, Optional, Union
 
-from pytoil.exceptions import MissingTokenError, MissingUsernameError
-
 from .config import Config
 
 # Type hint for generic JSON API response
@@ -99,12 +97,6 @@ class API:
         Returns:
             ApiResponse: JSON API response.
         """
-        # By this point if there's no token, something is wrong
-        if not self.token:
-            raise MissingTokenError(
-                """No GitHub personal access token set in .pytoil.yml.
-            Cannot access the GitHub API."""
-            )
 
         request = urllib.request.Request(
             url=self.baseurl + endpoint, method="GET", headers=self.headers
@@ -137,14 +129,7 @@ class API:
             APIResponse: JSON response for a particular repo.
         """
 
-        # By this point if there is no username, something is wrong
-        if not self.username:
-            raise MissingUsernameError(
-                f"""No GitHub username set in .pytoil.yml.
-            Cannot access repo: {repo!r}."""
-            )
-        else:
-            return self.get(f"repos/{self.username}/{repo}")
+        return self.get(f"repos/{self.username}/{repo}")
 
     def get_repos(self) -> APIResponse:
         """

--- a/pytoil/config.py
+++ b/pytoil/config.py
@@ -12,6 +12,8 @@ from typing import Dict, Optional, Union
 
 import yaml
 
+from .exceptions import InvalidConfigError
+
 
 class Config:
 
@@ -135,8 +137,30 @@ class Config:
             raise
         else:
             try:
-                # Return the config from unpacking the dict
-                return Config(**config_dict)
+                # Get the config from unpacking the dict
+                config = Config(**config_dict)
             except TypeError:
                 # If one of the keys is wrong
                 raise
+            else:
+                if config.token is None:
+                    raise InvalidConfigError(
+                        """GitHub personal access token is unset
+                in pytoil.yml config file. Please set a valid token in the key
+                `token`."""
+                    )
+                elif config.username is None:
+                    raise InvalidConfigError(
+                        """GitHub username is unset in
+                pytoil.yml config file. Please set a valid username in the key
+                `username`."""
+                    )
+                elif config.projects_dir is None:
+                    raise InvalidConfigError(
+                        """Projects dir is unset in pytoil.yml
+                config file. Please set the absolute path to your projects directory in
+                key `projects_dir`."""
+                    )
+                else:
+                    # If we get here, the config is valid
+                    return config

--- a/pytoil/exceptions.py
+++ b/pytoil/exceptions.py
@@ -22,3 +22,9 @@ class MissingUsernameError(Exception):
     def __init__(self, message: str) -> None:
         self.message = message
         super().__init__(self.message)
+
+
+class InvalidConfigError(Exception):
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(self.message)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,29 @@ def temp_config_file_missing_token(tmp_path_factory):
 
 
 @pytest.fixture
+def temp_config_file_missing_projects_dir(tmp_path_factory):
+    """
+    Returns an otherwise-valid config file but the projects_dir key
+    is blank
+
+    A blank value is interpreted by pyyaml as None.
+    """
+
+    config_file = tmp_path_factory.mktemp("temp").joinpath(".pytoil.yml")
+
+    yaml_dict: Dict[str, Union[str, None]] = {
+        "username": "tempfileuser",
+        "token": "tempfiletoken",
+        "projects_dir": None,
+    }
+
+    with open(config_file, "w") as f:
+        yaml.dump(yaml_dict, f)
+
+    return config_file
+
+
+@pytest.fixture
 def fake_api_response():
 
     response: APIResponse = [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,7 +11,6 @@ import pytest
 
 import pytoil
 from pytoil.api import API
-from pytoil.exceptions import MissingTokenError, MissingUsernameError
 
 
 def test_api_init_passed():
@@ -80,18 +79,6 @@ def test_api_setters():
     assert api.username == "someoneelse"
 
 
-def test_get_raises_on_missing_token(mocker, temp_config_file_missing_token):
-
-    with mocker.patch.object(
-        pytoil.config.Config, "CONFIG_PATH", temp_config_file_missing_token
-    ):
-
-        api = API()
-
-        with pytest.raises(MissingTokenError):
-            api.get("fake/endpoint")
-
-
 def test_get_raises_on_invalid_request(mocker, temp_config_file):
 
     with mocker.patch.object(pytoil.config.Config, "CONFIG_PATH", temp_config_file):
@@ -112,20 +99,6 @@ def test_get_raises_on_invalid_request(mocker, temp_config_file):
 
         with pytest.raises(urllib.error.HTTPError):
             api.get("not/here")
-
-
-def test_get_user_repo_raises_on_missing_username(
-    mocker, temp_config_file_missing_username
-):
-
-    with mocker.patch.object(
-        pytoil.config.Config, "CONFIG_PATH", temp_config_file_missing_username
-    ):
-
-        api = API()
-
-        with pytest.raises(MissingUsernameError):
-            api.get_repo(repo="fakerepo")
 
 
 def test_get_user_repo_correctly_calls_get(mocker, fake_api_response):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ import pytest
 
 import pytoil
 from pytoil.config import Config
+from pytoil.exceptions import InvalidConfigError
 
 
 def test_config_init_default():
@@ -105,42 +106,6 @@ def test_config_get_raises_on_missing_file(mocker):
             Config.get()
 
 
-def test_config_interprets_missing_keys_as_none(mocker, temp_config_file_missing_key):
-    """
-    Checks that if a key is missing from the yml file, the object is still
-    instantiated, but with None as the keys value.
-    """
-
-    with mocker.patch.object(
-        pytoil.config.Config, "CONFIG_PATH", temp_config_file_missing_key
-    ):
-        config = Config.get()
-
-    assert config.username == "tempfileuser"
-    # token is missing in the temp file
-    assert config.token is None
-    assert config.projects_dir == pathlib.Path("Users/tempfileuser/projects")
-
-
-def test_config_interprets_blank_value_as_none(
-    mocker, temp_config_file_key_with_blank_value
-):
-    """
-    Checks that if a key is present in the yml file, but it's value is blank. This
-    is also treated as None.
-    """
-
-    with mocker.patch.object(
-        pytoil.config.Config, "CONFIG_PATH", temp_config_file_key_with_blank_value
-    ):
-        config = Config.get()
-
-    assert config.username == "tempfileuser"
-    # token key is present but value is blank
-    assert config.token is None
-    assert config.projects_dir == pathlib.Path("Users/tempfileuser/projects")
-
-
 def test_config_raises_on_misspelled_key(mocker, temp_config_file_misspelled_key):
     """
     Checks that config.get will raise a TypeError when one of the keys in
@@ -151,4 +116,33 @@ def test_config_raises_on_misspelled_key(mocker, temp_config_file_misspelled_key
         pytoil.config.Config, "CONFIG_PATH", temp_config_file_misspelled_key
     ):
         with pytest.raises(TypeError):
+            Config.get()
+
+
+def test_config_raises_on_missing_username(mocker, temp_config_file_missing_username):
+
+    with mocker.patch.object(
+        pytoil.config.Config, "CONFIG_PATH", temp_config_file_missing_username
+    ):
+        with pytest.raises(InvalidConfigError):
+            Config.get()
+
+
+def test_config_raises_on_missing_token(mocker, temp_config_file_missing_token):
+
+    with mocker.patch.object(
+        pytoil.config.Config, "CONFIG_PATH", temp_config_file_missing_token
+    ):
+        with pytest.raises(InvalidConfigError):
+            Config.get()
+
+
+def test_config_raises_on_missing_projects_dir(
+    mocker, temp_config_file_missing_projects_dir
+):
+
+    with mocker.patch.object(
+        pytoil.config.Config, "CONFIG_PATH", temp_config_file_missing_projects_dir
+    ):
+        with pytest.raises(InvalidConfigError):
             Config.get()


### PR DESCRIPTION
Tweaked the config implementation such that the classmethod
get can no longer return a Config object which has any arguments
of None.

If the config file has blank values or misspelled keys, get will
raise an exception.

Only if the config contains actual values for each key will
get return a Config object.

These values may still be incorrect so some external checking is still
required but the primary validation of the config now happens
in the config module which I think makes more sense.
