### PR TITLE
Change from urllib to urllib3.

### DIFF
--- a/docs/img/coverage.svg
+++ b/docs/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">95%</text>
-        <text x="80" y="14">95%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">97%</text>
+        <text x="80" y="14">97%</text>
     </g>
 </svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ typer = {extras = ["all"], version = "^0.3.2"}
 virtualenv = "^20.4.2"
 PyYAML = "^5.4.1"
 cookiecutter = "^1.7.2"
+urllib3 = "^1.26.3"
 
 [tool.poetry.dev-dependencies]
 bump2version = "^1.0"

--- a/pytoil/exceptions.py
+++ b/pytoil/exceptions.py
@@ -82,3 +82,10 @@ class InvalidURLError(Exception):
     def __init__(self, message: str) -> None:
         self.message = message
         super().__init__(self.message)
+
+
+class APIRequestError(Exception):
+    def __init__(self, message: str, status_code: int) -> None:
+        self.message = message
+        self.status_code = status_code
+        super().__init__(self.message, self.status_code)

--- a/pytoil/repo.py
+++ b/pytoil/repo.py
@@ -12,12 +12,12 @@ import pathlib
 import re
 import shutil
 import subprocess
-import urllib.error
 from typing import Optional
 
 from .api import API
 from .config import Config
 from .exceptions import (
+    APIRequestError,
     GitNotInstalledError,
     InvalidURLError,
     LocalRepoExistsError,
@@ -114,9 +114,9 @@ class Repo:
         try:
             api = API()
             api.get_repo(repo=self.name)
-        except urllib.error.HTTPError as err:
-            # Any HTTPError
-            if err.code == 404:
+        except APIRequestError as err:
+            # Any non 200 response status
+            if err.status_code == 404:
                 # If specifically 404 not found
                 # repo doesn't exist
                 return False


### PR DESCRIPTION
Refactored API and Repo to instead make use of urllib3 as
urllib3 is installed with cookiecutter so we may aswell make
use of it where we can.

Use of urllib3 actually simplifies some of the error handling
logic and the testing.
