### PR TITLE
Remove ability to fork other peoples repos.

### DIFF
--- a/pytoil/cli/main.py
+++ b/pytoil/cli/main.py
@@ -37,12 +37,11 @@ def main(
     """
     Helpful CLI to automate the development workflow.
 
-    Create and easily resume local or remote
-    development projects.
+    - Create and manage your local and remote projects
 
-    Build projects from cookiecutter templates.
+    - Build projects from cookiecutter templates.
 
-    Easily create/manage virtual environments.
+    - Easily create/manage virtual environments.
 
-    Minimal configuration required.
+    - Minimal configuration required.
     """

--- a/pytoil/exceptions.py
+++ b/pytoil/exceptions.py
@@ -76,10 +76,3 @@ class InvalidRepoPathError(Exception):
     def __init__(self, message: str) -> None:
         self.message = message
         super().__init__(self.message)
-
-
-class APIRequestError(Exception):
-    def __init__(self, message: str, status_code: int) -> None:
-        self.message = message
-        self.status_code = status_code
-        super().__init__(self.message, self.status_code)

--- a/pytoil/repo.py
+++ b/pytoil/repo.py
@@ -17,7 +17,6 @@ from typing import Optional, Set
 from .api import API
 from .config import Config
 from .exceptions import (
-    APIRequestError,
     GitNotInstalledError,
     InvalidRepoPathError,
     InvalidURLError,
@@ -137,7 +136,7 @@ class Repo:
     def exists_remote(self) -> bool:
         """
         Determines whether or not the repo called
-        `self.name` exists under owner `self.owner`.
+        `self.name` exists under configured username.
 
         Returns:
             bool: True if repo exists on GitHub, else False.
@@ -191,45 +190,6 @@ class Repo:
             else:
                 # If clone succeeded, set self.path
                 self.path = config.projects_dir.joinpath(self.name)
-
-    def fork(self) -> str:
-        """
-        Forks the repo described by the instance as long
-        as the repo owner is not the current user.
-
-        In order to fork, the user must specify class attribute `owner`
-        as well as `name`.
-
-        If the fork is accepted, will return the URL of the user's
-        new fork.
-
-        Forking happens asynchronously on the GitHub API so the users
-        fork may not be immediately ready to clone.
-
-        i.e. if user forks "someoneelse/repo" the returned url will
-        be: "https://github.com/theuser/repo.git"
-
-        Raises:
-            APIRequestError: If any HTTP error occurs during the fork.
-
-        Returns:
-            str: The URL of the user's new fork.
-        """
-
-        # Validate user config
-        config = Config.get()
-        config.raise_if_unset()
-
-        api = API()
-
-        try:
-            api.fork_repo(owner=self.owner, name=self.name)
-        except APIRequestError:
-            # Only raises if the fork belongs to the user
-            raise
-        else:
-            # Return the URL of the users new fork
-            return f"https://github.com/{config.username}/{self.name}.git"
 
     def _does_file_exist(self, file: str) -> bool:
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,6 @@ from pytest_httpx import HTTPXMock
 
 import pytoil
 from pytoil.api import API
-from pytoil.exceptions import APIRequestError
 
 
 def test_api_init_passed():
@@ -119,42 +118,6 @@ def test_get_returns_correct_response(
         assert r == fake_api_response
 
 
-@pytest.mark.parametrize("bad_status_code", [400, 401, 403, 404, 500, 504, 505])
-def test_post_raises_on_bad_status(
-    httpx_mock: HTTPXMock, mocker, temp_config_file, bad_status_code
-):
-
-    with mocker.patch.object(pytoil.config, "CONFIG_PATH", temp_config_file):
-
-        httpx_mock.add_response(
-            url="https://api.github.com/user/repos", status_code=bad_status_code
-        )
-
-        api = API(token="definitelynotatoken", username="me")
-
-        with pytest.raises(httpx.HTTPStatusError):
-            api.post("user/repos")
-
-
-def test_post_returns_correct_response(
-    httpx_mock: HTTPXMock, fake_api_response, mocker, temp_config_file
-):
-
-    with mocker.patch.object(pytoil.config, "CONFIG_PATH", temp_config_file):
-
-        httpx_mock.add_response(
-            url="https://api.github.com/user/repos",
-            json=fake_api_response,
-            status_code=200,
-        )
-
-        api = API(token="definitelynotatoken", username="me")
-
-        r = api.post("user/repos")
-
-        assert r == fake_api_response
-
-
 def test_get_user_repo_correctly_calls_get(mocker, fake_api_response):
 
     mocker.patch("pytoil.api.API.get", autospec=True, return_value=fake_api_response)
@@ -183,35 +146,3 @@ def test_get_repo_names_correctly_calls_get_repos(mocker, fake_api_response):
 
     # The names are contained in the fake_api_response fixture in conftest.py
     assert api.get_repo_names() == ["repo1", "repo2", "repo3"]
-
-
-def test_fork_repo_raises_if_owner_matches_username(mocker, temp_config_file):
-
-    # Patch the default config file location to our temp file
-    with mocker.patch.object(pytoil.config, "CONFIG_PATH", temp_config_file):
-
-        api = API(token="notatoken", username="hello")
-
-        with pytest.raises(APIRequestError):
-            api.fork_repo(owner="hello", name="project")
-
-
-def test_fork_repo_returns_if_owner_doesnt_match_username(mocker, temp_config_file):
-
-    # Patch the default config file location to our temp file
-    with mocker.patch.object(pytoil.config, "CONFIG_PATH", temp_config_file):
-
-        # Patch out api.post to return some arbitrary json
-        # and more importantly, not actually hit the GitHub API
-        mocker.patch(
-            "pytoil.api.API.post",
-            autospec=True,
-            return_value={"arbitrary": "json", "blob": "yes"},
-        )
-
-        api = API(token="notatoken", username="hello")
-
-        # Fork a repo with a different user name
-        response = api.fork_repo(owner="someoneelse", name="project")
-
-        assert response == {"arbitrary": "json", "blob": "yes"}


### PR DESCRIPTION
Decided to remove the ability to fork other peoples repos
by making a POST request. Few reasons:

- Complexity of dealing with user owned repos and forks
- Constant checking of repo ownership
- Much safer and more trustworthy if we only make GET requests
- CLI is now FAR simpler and easier to maintain
- Other clients out there do a much better job of forking
eg gh cli
