### PR TITLE
Restructure the way config works.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,7 +34,7 @@ def poetry_install(session: nox.Session, *args: str, **kwargs: Any) -> None:
         session.install(f"--constraint={requirements.name}", *args, **kwargs)
 
 
-@nox.session(python=["3.7", "3.8", "3.9"])
+@nox.session(python=["3.8", "3.9"])
 def test(session: nox.Session) -> None:
     """
     Runs the test suite against all supported python versions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
 ]
@@ -29,7 +28,7 @@ pytoil = "pytoil.cli.main:app"
 "Documentation" = "https://FollowTheProcess.github.io/pytoil/"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 typer = {extras = ["all"], version = "^0.3.2"}
 virtualenv = "^20.4.2"
 PyYAML = "^5.4.1"

--- a/pytoil/api.py
+++ b/pytoil/api.py
@@ -98,7 +98,7 @@ class API:
         """
         # This needs the token from the config
         # it could be invalid, we haven't checked until now
-        Config.get().raise_if_unset()
+        Config.get().validate()
 
         r = httpx.get(url=self.baseurl + endpoint, headers=self.headers)
         r.raise_for_status()

--- a/pytoil/cli/main.py
+++ b/pytoil/cli/main.py
@@ -5,6 +5,8 @@ Author: Tom Fleet
 Created: 24/02/2021
 """
 
+import pathlib
+
 import typer
 
 from pytoil import __version__
@@ -70,7 +72,11 @@ def init() -> None:
         token: str = typer.prompt("GitHub personal access token")
         projects_dir: str = typer.prompt("Absolute path to your projects directory")
 
-        user_config = Config(username=username, token=token, projects_dir=projects_dir)
+        projects_dir_path = pathlib.Path(projects_dir)
+
+        user_config = Config(
+            username=username, token=token, projects_dir=projects_dir_path
+        )
         user_config.write()
 
         typer.secho("Config written, you're good to go!", fg=typer.colors.GREEN)

--- a/pytoil/cli/project.py
+++ b/pytoil/cli/project.py
@@ -96,7 +96,7 @@ def create(
 
     # Everything below requires a valid config
     config = Config.get()
-    config.raise_if_unset()
+    config.validate()
 
     # Create the project repo object
     repo = Repo(name=project)
@@ -190,7 +190,7 @@ def checkout(
 
     # Everything below requires a valid config
     config = Config.get()
-    config.raise_if_unset()
+    config.validate()
 
     # Project exists either locally or on users GitHub
     # and is to be grabbed by name only
@@ -249,7 +249,7 @@ def remove(
 
     # Everything below needs a valid config
     config = Config.get()
-    config.raise_if_unset()
+    config.validate()
 
     # Set because we don't care about sorting
     # but we want fast membership checking
@@ -309,7 +309,7 @@ def info(
     """
 
     config = Config.get()
-    config.raise_if_unset()
+    config.validate()
 
     repo = Repo(name=project)
 

--- a/pytoil/cli/show.py
+++ b/pytoil/cli/show.py
@@ -30,7 +30,7 @@ def local() -> None:
     """
 
     config = Config.get()
-    config.raise_if_unset()
+    config.validate()
 
     local_projects: List[str] = sorted(
         [
@@ -61,7 +61,7 @@ def remote() -> None:
     """
 
     config = Config.get()
-    config.raise_if_unset()
+    config.validate()
 
     api = API()
 
@@ -88,7 +88,7 @@ def all_() -> None:
     """
 
     config = Config.get()
-    config.raise_if_unset()
+    config.validate()
 
     api = API()
 
@@ -136,7 +136,7 @@ def diff() -> None:
 
     # Everything below requires a valid config
     config = Config.get()
-    config.raise_if_unset()
+    config.validate()
 
     api = API()
 

--- a/pytoil/cli/sync.py
+++ b/pytoil/cli/sync.py
@@ -53,7 +53,7 @@ def all_(
 
     # Everything below requires a valid config
     config = Config.get()
-    config.raise_if_unset()
+    config.validate()
 
     api = API()
 
@@ -128,7 +128,7 @@ def these(
 
     # Everything below requires a valid config
     config = Config.get()
-    config.raise_if_unset()
+    config.validate()
 
     local_projects: Set[str] = {
         f.name

--- a/pytoil/repo.py
+++ b/pytoil/repo.py
@@ -163,7 +163,7 @@ class Repo:
 
         # Get the user config from file and validate
         config = Config.get()
-        config.raise_if_unset()
+        config.validate()
 
         # Check if git is installed
         if not bool(shutil.which("git")):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ def temp_config_file(tmp_path_factory):
         "username": "tempfileuser",
         "token": "tempfiletoken",
         "projects_dir": "/Users/tempfileuser/projects",
+        "vscode": True,
     }
 
     with open(config_file, "w") as f:
@@ -46,6 +47,7 @@ def temp_config_file_missing_key(tmp_path_factory):
     yaml_dict: Dict[str, str] = {
         "username": "tempfileuser",
         "projects_dir": "/Users/tempfileuser/projects",
+        "vscode": True,
     }
 
     with open(config_file, "w") as f:
@@ -71,6 +73,7 @@ def temp_config_file_key_with_blank_value(tmp_path_factory):
         "username": "tempfileuser",
         "token": None,
         "projects_dir": "/Users/tempfileuser/projects",
+        "vscode": True,
     }
 
     with open(config_file, "w") as f:
@@ -115,6 +118,7 @@ def temp_config_file_missing_username(tmp_path_factory):
         "username": None,
         "token": "tempfiletoken",
         "projects_dir": "/Users/tempfileuser/projects",
+        "vscode": True,
     }
 
     with open(config_file, "w") as f:
@@ -138,6 +142,7 @@ def temp_config_file_missing_token(tmp_path_factory):
         "username": "tempfileuser",
         "token": None,
         "projects_dir": "/Users/tempfileuser/projects",
+        "vscode": True,
     }
 
     with open(config_file, "w") as f:
@@ -161,6 +166,31 @@ def temp_config_file_missing_projects_dir(tmp_path_factory):
         "username": "tempfileuser",
         "token": "tempfiletoken",
         "projects_dir": None,
+        "vscode": True,
+    }
+
+    with open(config_file, "w") as f:
+        yaml.dump(yaml_dict, f)
+
+    return config_file
+
+
+@pytest.fixture
+def temp_config_file_missing_vs_code(tmp_path_factory):
+    """
+    Returns an otherwise-valid config file but the projects_dir key
+    is blank
+
+    A blank value is interpreted by pyyaml as None.
+    """
+
+    config_file = tmp_path_factory.mktemp("temp").joinpath(".pytoil.yml")
+
+    yaml_dict: Dict[str, Union[str, None]] = {
+        "username": "tempfileuser",
+        "token": "tempfiletoken",
+        "projects_dir": "/Users/tempfileuser/projects",
+        "vscode": None,
     }
 
     with open(config_file, "w") as f:


### PR DESCRIPTION
I went to add a "vscode" key to the config to represent whether
the user's preferred editor is vscode, in which case we can
open it etc.

However, I quickly realised how horrible this process is and that
doesn't bode well for maintainability. So I've restructured
how config works, it is now a dataclass and the dict representation
of it as returned by pyyaml is now a typed dict which acts as sort of
a schema.

Hopefully, this is an improvement.
