### PR TITLE
Add auto-detection of the conda envs folder.

### DIFF
--- a/pytoil/env.py
+++ b/pytoil/env.py
@@ -19,6 +19,7 @@ from .exceptions import (
     CondaNotInstalledError,
     MissingInterpreterError,
     TargetDirDoesNotExistError,
+    UnknownCondaInstallationError,
     VirtualenvAlreadyExistsError,
     VirtualenvDoesNotExistError,
 )
@@ -504,3 +505,32 @@ class CondaEnv:
             subprocess.run(cmd, check=True)
         except subprocess.CalledProcessError:
             raise
+
+    @staticmethod
+    def get_envs_dir() -> pathlib.Path:
+        """
+        Tries to detect which anaconda/miniconda installation
+        the user has by naively checking if the environment
+        storage directories exist.
+
+        Raises:
+            UnknownCondaInstallationError: If neither ~/anaconda3 or
+                ~/miniconda3 exist or are not directories.
+
+        Returns:
+            pathlib.Path: The path to the users conda
+                environment storage directory.
+        """
+
+        # As far as I'm aware, there are only 2 possible locations
+        miniconda = pathlib.Path.home().joinpath("miniconda3/envs")
+        anaconda = pathlib.Path.home().joinpath("anaconda3/envs")
+
+        if miniconda.exists() and miniconda.is_dir():
+            return miniconda
+        elif anaconda.exists() and anaconda.is_dir():
+            return anaconda
+        else:
+            raise UnknownCondaInstallationError(
+                "Could not autodetect the conda environments directory."
+            )

--- a/pytoil/exceptions.py
+++ b/pytoil/exceptions.py
@@ -82,3 +82,9 @@ class CodeNotInstalledError(Exception):
     def __init__(self, message: str) -> None:
         self.message = message
         super().__init__(self.message)
+
+
+class UnknownCondaInstallationError(Exception):
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(self.message)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -355,3 +355,54 @@ def fake_vscode_workspace_settings(tmp_path_factory):
         json.dump(settings_dict, f)
 
     return settings_json
+
+
+@pytest.fixture
+def fake_home_folder_miniconda(tmp_path_factory):
+    """
+    Returns a faked $HOME folder. Should be used as the return
+    value from pathlib.Path.home().
+
+    Designed to test the auto detection of conda environment
+    storage directory.
+    """
+
+    fake_home: pathlib.Path = tmp_path_factory.mktemp("home")
+
+    # Add in the miniconda3/envs folder
+    miniconda = fake_home.joinpath("miniconda3/envs")
+    miniconda.mkdir(parents=True)
+
+    return fake_home
+
+
+@pytest.fixture
+def fake_home_folder_anaconda(tmp_path_factory):
+    """
+    Returns a faked $HOME folder. Should be used as the return
+    value from pathlib.Path.home().
+
+    Designed to test the auto detection of conda environment
+    storage directory.
+    """
+
+    fake_home: pathlib.Path = tmp_path_factory.mktemp("home")
+
+    # Add in the anaconda3/envs folder
+    anaconda = fake_home.joinpath("anaconda3/envs")
+    anaconda.mkdir(parents=True)
+
+    return fake_home
+
+
+@pytest.fixture
+def fake_home_folder_neither(tmp_path_factory):
+    """
+    Returns a faked $HOME but without any conda dirs.
+
+    To test whether get_envs_dir raises correctly.
+    """
+
+    fake_home: pathlib.Path = tmp_path_factory.mktemp("home")
+
+    return fake_home

--- a/tests/test_condaenv.py
+++ b/tests/test_condaenv.py
@@ -16,6 +16,7 @@ from pytoil.env import CondaEnv
 from pytoil.exceptions import (
     BadEnvironmentFileError,
     CondaNotInstalledError,
+    UnknownCondaInstallationError,
     VirtualenvAlreadyExistsError,
     VirtualenvDoesNotExistError,
 )
@@ -380,3 +381,51 @@ def test_condaenv_export_yml_exports_correct_content(
         capture_output=True,
         encoding="utf-8",
     )
+
+
+def test_condaenv_get_envs_dir_returns_correctly_for_miniconda(
+    mocker: MockerFixture, fake_home_folder_miniconda: pathlib.Path
+):
+
+    mocker.patch(
+        "pytoil.env.pathlib.Path.home",
+        autospec=True,
+        return_value=fake_home_folder_miniconda,
+    )
+
+    env = CondaEnv.get_envs_dir()
+
+    expected_env_dir = fake_home_folder_miniconda.joinpath("miniconda3/envs")
+
+    assert env == expected_env_dir
+
+
+def test_condaenv_get_envs_dir_returns_correctly_for_anaconda(
+    mocker: MockerFixture, fake_home_folder_anaconda: pathlib.Path
+):
+
+    mocker.patch(
+        "pytoil.env.pathlib.Path.home",
+        autospec=True,
+        return_value=fake_home_folder_anaconda,
+    )
+
+    env = CondaEnv.get_envs_dir()
+
+    expected_env_dir = fake_home_folder_anaconda.joinpath("anaconda3/envs")
+
+    assert env == expected_env_dir
+
+
+def test_condaenv_get_envs_dir_raises_if_neither_found(
+    mocker: MockerFixture, fake_home_folder_neither: pathlib.Path
+):
+
+    mocker.patch(
+        "pytoil.env.pathlib.Path.home",
+        autospec=True,
+        return_value=fake_home_folder_neither,
+    )
+
+    with pytest.raises(UnknownCondaInstallationError):
+        CondaEnv.get_envs_dir()


### PR DESCRIPTION
In order to configure VSCode workspace with the correct python path
we need to know which conda (miniconda/anaconda) the user has installed.

Initially I thought about parsing the return from `conda info` but
I felt that would be unreliable and it's a lot of string
manipulation.

So I settled on a Naive check whether or not the appropriate
$HOME/miniconda3 (or anaconda3) directories existed.
