### PR TITLE
Fix bug in config show on missing file.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,9 +16,9 @@ Below are a list of enhancements or fixes discovered during pre-release testing:
 ### Legit Changes Requiring Tests
 
 - [x] Setting python path in vscode settings errors if file is missing or it's empty
-- [ ] Creating from a cookiecutter with no virtual environment doesn't open code
-- [ ] Pytoil config show raises ugly error when config file doesn't exist
-- [ ] Same with config set
+- [x] Creating from a cookiecutter with no virtual environment doesn't open code
+- [x] Pytoil config show raises ugly FileNotFound error when config file doesn't exist
+- [x] Same with config set
 - [ ] Make pytoil init check more robust than just whether or not the file exists. See if it has the right keys etc. Or even just a check that it's not empty.
 - [ ] Creating a new conda project when the environment already exists raises an ugly error. Should instead just set the python path in vscode (if configured)
 - [ ] "Virtualenv not requested, skipping" message should have a new line before it

--- a/pytoil/cli/config.py
+++ b/pytoil/cli/config.py
@@ -41,11 +41,15 @@ def show() -> None:
     """
 
     # Get config but don't raise on UNSET
-    config = Config.get()
-
-    typer.secho("\nCurrent pytoil config:", fg=typer.colors.BLUE, bold=True)
-    typer.echo("")
-    config.show()
+    try:
+        config = Config.get()
+    except FileNotFoundError:
+        typer.secho("No config file yet!", fg=typer.colors.YELLOW)
+        typer.echo("Run '$ pytoil init' to automatically generate one.")
+    else:
+        typer.secho("\nCurrent pytoil config:", fg=typer.colors.BLUE, bold=True)
+        typer.echo("")
+        config.show()
 
 
 @app.command()
@@ -83,29 +87,34 @@ def set(
 
     # Get any existing config
     # but don't validate
-    config = Config.get()
+    try:
+        config = Config.get()
+    except FileNotFoundError:
+        typer.secho("No config file yet!", fg=typer.colors.YELLOW)
+        typer.echo("Run '$ pytoil init' to automatically generate one.")
+    else:
 
-    # I'm not keen on this, it feels messy
-    if username:
-        config.username = username
-    elif token:
-        config.token = token
-    elif projects_dir:
-        config.projects_dir = projects_dir
-    elif vscode:  # pragma: no cover
-        # If we use vscode as a boolean option it doesn't quite work right
-        # also for some reason coverage doesn't recognise this as being called
-        # during tests but it is in tests/cli/test_config.py so we exclude it from cov
-        if vscode.lower() == "true":
-            config.vscode = True
-        elif vscode.lower() == "false":
-            config.vscode = False
-        else:
-            raise typer.BadParameter("vscode must be a boolean value.")
+        # I'm not keen on this, it feels messy
+        if username:
+            config.username = username
+        elif token:
+            config.token = token
+        elif projects_dir:
+            config.projects_dir = projects_dir
+        elif vscode:  # pragma: no cover
+            # If we use vscode as a boolean option it doesn't quite work right
+            # also for some reason coverage doesn't recognise this as being called
+            # during tests but it is in tests/cli/test_config.py so we exclude it
+            if vscode.lower() == "true":
+                config.vscode = True
+            elif vscode.lower() == "false":
+                config.vscode = False
+            else:
+                raise typer.BadParameter("vscode must be a boolean value.")
 
-    # Write the updated config
-    config.write()
+        # Write the updated config
+        config.write()
 
-    typer.secho("\nConfig updated successfully!", fg=typer.colors.GREEN)
-    typer.secho("\nNew Config:\n", fg=typer.colors.BLUE, bold=True)
-    config.show()
+        typer.secho("\nConfig updated successfully!", fg=typer.colors.GREEN)
+        typer.secho("\nNew Config:\n", fg=typer.colors.BLUE, bold=True)
+        config.show()

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -111,3 +111,39 @@ def test_config_set_vscode_correctly_converts_str_to_bool(
             new_config_dict = yaml.full_load(f)
 
         assert new_config_dict.get("vscode") == boolean
+
+
+def test_config_show_correctly_handles_file_not_found_error(
+    mocker: MockerFixture, temp_config_file
+):
+
+    with mocker.patch.object(pytoil.config.config, "CONFIG_PATH", temp_config_file):
+
+        mocker.patch(
+            "pytoil.config.config.Config.get",
+            autospec=True,
+            side_effect=[FileNotFoundError()],
+        )
+
+        result = runner.invoke(app, ["config", "show"])
+        assert result.exit_code == 0
+        assert "No config file yet!" in result.stdout
+        assert "Run '$ pytoil init' to automatically generate one." in result.stdout
+
+
+def test_config_set_correctly_handles_file_not_found_error(
+    mocker: MockerFixture, temp_config_file
+):
+
+    with mocker.patch.object(pytoil.config.config, "CONFIG_PATH", temp_config_file):
+
+        mocker.patch(
+            "pytoil.config.config.Config.get",
+            autospec=True,
+            side_effect=[FileNotFoundError()],
+        )
+
+        result = runner.invoke(app, ["config", "set", "--vscode", "False"])
+        assert result.exit_code == 0
+        assert "No config file yet!" in result.stdout
+        assert "Run '$ pytoil init' to automatically generate one." in result.stdout


### PR DESCRIPTION
There was a bug in config show and config set where
if the config file didn't exist, the `config.get()` method
would throw a `FileNotFoundError` which was not adequately
handled by the CLI causing an ugly raise to the user.

This commit fixes this bug and adds tests for it.
