### PR TITLE
Make init a bit more robust.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,7 @@ Below are a list of enhancements or fixes discovered during pre-release testing:
 - [x] "Project: project found on your GitHub" message in project checkout should be bold and blue like the others and have a new line before it
 - [x] "Unable to detect virtual environment, skipping" in project checkout should have new line before and after as comes after git clone output
 - [x] "project is available locally" should be in bold and blue not green to be consistent.
+- [x] "Virtualenv not requested, skipping" message should have a new line before it
 
 ### Legit Changes Requiring Tests
 
@@ -19,10 +20,9 @@ Below are a list of enhancements or fixes discovered during pre-release testing:
 - [x] Creating from a cookiecutter with no virtual environment doesn't open code
 - [x] Pytoil config show raises ugly FileNotFound error when config file doesn't exist
 - [x] Same with config set
-- [ ] Make pytoil init check more robust than just whether or not the file exists. See if it has the right keys etc. Or even just a check that it's not empty.
+- [x] Make pytoil init check more robust than just whether or not the file exists. See if it has the right keys etc. Or even just a check that it's not empty.
 - [ ] Creating a new conda project when the environment already exists raises an ugly error. Should instead just set the python path in vscode (if configured)
-- [ ] "Virtualenv not requested, skipping" message should have a new line before it
-- [ ] If user hits ctrl+c during pytoil init, the config is half written and can cause bugs later. Make it instead delete the whole thing unless run to completion
+- [ ] If user hits ctrl+c during pytoil init, the config is half written and can cause bugs later. Make it instead delete the whole thing unless run to completion. Maybe a try except on `KeyboardInterrupt`? Or is this dangerous? Might never terminate etc.
 
 ## Longer Term Enhancements
 

--- a/pytoil/cli/main.py
+++ b/pytoil/cli/main.py
@@ -12,6 +12,7 @@ import typer
 from pytoil import __version__
 from pytoil.cli import config, project, show, sync
 from pytoil.config import CONFIG_PATH, Config
+from pytoil.exceptions import InvalidConfigError
 
 # Add all the subcommands
 app = typer.Typer(name="pytoil", no_args_is_help=True)
@@ -96,4 +97,15 @@ def init() -> None:
 
         typer.secho("Config written, you're good to go!", fg=typer.colors.GREEN)
     else:
-        typer.secho("You're all set!", fg=typer.colors.GREEN)
+        try:
+            config = Config.get()
+            config.validate()
+        except InvalidConfigError:
+            typer.secho(
+                "Something's wrong in the config file, please check it.",
+                fg=typer.colors.RED,
+            )
+            typer.echo("If in doubt, simply delete it and run '$ pytoil init' again :)")
+            raise typer.Abort()
+        else:
+            typer.secho("You're all set!", fg=typer.colors.GREEN)

--- a/pytoil/cli/project.py
+++ b/pytoil/cli/project.py
@@ -182,7 +182,9 @@ def create(
                 typer.echo(f"Opening {project!r} in VSCode...")
                 vscode.open()
     else:
-        typer.echo("Virtual environment not requested. Skipping environment creation.")
+        typer.echo(
+            "\nVirtual environment not requested. Skipping environment creation."
+        )
         if config.vscode:
             typer.echo(f"Opening {project!r} in VSCode...")
             vscode.open()


### PR DESCRIPTION
pytoil init is now a bit more robust against invalid config.

It no longer just checks if the file exists but does some basic
validation and suggests actions to the user if it fails.
