### PR TITLE
Fix conda env create if exists bug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ pytoil project create my_project --venv virtualenv
 #### And even do this from a [cookiecutter] template
 
 ```shell
-pytoil project create my_project --venv virtualenv --cookiecutter https://github.com/some/cookie.git
+pytoil project create my_project --venv virtualenv --cookie https://github.com/some/cookie.git
 ```
 
 Check out the [docs] for more :boom:

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,7 @@ Below are a list of enhancements or fixes discovered during pre-release testing:
 - [x] "Unable to detect virtual environment, skipping" in project checkout should have new line before and after as comes after git clone output
 - [x] "project is available locally" should be in bold and blue not green to be consistent.
 - [x] "Virtualenv not requested, skipping" message should have a new line before it
+- [x] README still shows old cookiecutter option, change to --cookie
 
 ### Legit Changes Requiring Tests
 
@@ -21,7 +22,7 @@ Below are a list of enhancements or fixes discovered during pre-release testing:
 - [x] Pytoil config show raises ugly FileNotFound error when config file doesn't exist
 - [x] Same with config set
 - [x] Make pytoil init check more robust than just whether or not the file exists. See if it has the right keys etc. Or even just a check that it's not empty.
-- [ ] Creating a new conda project when the environment already exists raises an ugly error. Should instead just set the python path in vscode (if configured)
+- [x] Creating a new conda project when the environment already exists raises an ugly error. Should instead just set the python path in vscode (if configured)
 - [ ] If user hits ctrl+c during pytoil init, the config is half written and can cause bugs later. Make it instead delete the whole thing unless run to completion. Maybe a try except on `KeyboardInterrupt`? Or is this dangerous? Might never terminate etc.
 
 ## Longer Term Enhancements

--- a/tests/cli/test_project_checkout.py
+++ b/tests/cli/test_project_checkout.py
@@ -13,6 +13,7 @@ from typer.testing import CliRunner
 from pytoil.cli.main import app
 from pytoil.config import Config
 from pytoil.environments import CondaEnv, VirtualEnv
+from pytoil.exceptions import VirtualenvAlreadyExistsError
 
 runner = CliRunner()
 
@@ -452,4 +453,79 @@ def test_checkout_remote_correctly_sets_up_conda_environment_with_code(
     assert "Setting 'python.pythonPath' in VSCode workspace..." in result.stdout
     mock_code_ppath.assert_called_once()
     assert "Opening 'conda_project' in VSCode..." in result.stdout
+    mock_code_open.assert_called_once()
+
+
+def test_project_checkout_handles_conda_env_already_existing(
+    mocker: MockerFixture, fake_projects_dir
+):
+
+    fake_config = Config(
+        username="test",
+        token="testtoken",
+        projects_dir=fake_projects_dir,
+        vscode=True,
+    )
+
+    mocker.patch(
+        "pytoil.cli.project.Config.get",
+        autospec=True,
+        return_value=fake_config,
+    )
+
+    mocker.patch(
+        "pytoil.cli.project.Repo.exists_local", autospec=True, return_value=False
+    )
+
+    mocker.patch(
+        "pytoil.cli.project.Repo.exists_remote", autospec=True, return_value=True
+    )
+
+    mocker.patch(
+        "pytoil.cli.project.CondaEnv.exists",
+        autospec=True,
+        return_value=True,
+    )
+
+    mocker.patch(
+        "pytoil.cli.project.CondaEnv.get_envs_dir",
+        autospec=True,
+        return_value=fake_projects_dir.parent.joinpath("miniconda3"),
+    )
+
+    mock_clone = mocker.patch("pytoil.cli.project.Repo.clone", autospec=True)
+
+    mock_conda_create = mocker.patch(
+        "pytoil.cli.project.CondaEnv.create",
+        autospec=True,
+        side_effect=VirtualenvAlreadyExistsError("Already here you fool!"),
+    )
+
+    mock_code_open = mocker.patch("pytoil.cli.project.VSCode.open", autospec=True)
+    mock_code_ppath = mocker.patch(
+        "pytoil.cli.project.VSCode.set_python_path", autospec=True
+    )
+    mock_env_dispatcher = mocker.patch(
+        "pytoil.cli.project.env_dispatcher",
+        autospec=True,
+        return_value=CondaEnv(
+            name="mynewproject", project_path=fake_projects_dir.joinpath("mynewproject")
+        ),
+    )
+
+    result = runner.invoke(app, ["project", "checkout", "mynewproject"])
+    mock_clone.assert_called_once()
+    mock_env_dispatcher.assert_called_once()
+    mock_conda_create.assert_called_once()
+    assert result.exit_code == 0
+
+    assert (
+        "Matching environment already exists. No need to create a new one!"
+        in result.stdout
+    )
+
+    assert "Setting 'python.pythonPath' in VSCode workspace." in result.stdout
+    mock_code_ppath.assert_called_once()
+
+    assert "Opening 'mynewproject' in VSCode" in result.stdout
     mock_code_open.assert_called_once()


### PR DESCRIPTION
There was a bug where if you pytoil checkout a project
that already had an existing conda environment on the system,
it would raise a nasty error.

This exception is now handled and pytoil will now simply use the
existing environment as if it just created it.

This commit fixes this bug and adds tests for it.
