### PR TITLE
Fix init ctrl+c bug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.dev
+
+* FIX: `pytoil init` now gracefully exits on ctrl+c preventing a bug where if a user aborted halfway through, the config file would appear to have been written but would not be valid and raise an ugly error on next use.
+
 ## 0.1.0
 
 * First release.

--- a/TODO.md
+++ b/TODO.md
@@ -2,30 +2,21 @@
 
 Below are a list of enhancements or fixes discovered during pre-release testing:
 
-## Immediate Fixes
-
-### Easy Tweaks
-
-- [ ] After "creating project...." the line spacing is inconsistent. Should be one new line before "Virtual env not requested" and one before "opening in vscode"
-
-### Legit Changes Requiring Tests
-
-- [ ] If user hits ctrl+c during pytoil init, the config is half written and can cause bugs later. Make it instead delete the whole thing unless run to completion. Maybe a try except on `KeyboardInterrupt`? Then in the `except` ensure the config file is deleted and no changes are persisted, then gracefully exit.
-
 ## Longer Term Enhancements
 
-### High Priority
+### Hot
 
 - [ ] Make it automatically install requirements if a file present. For setuptools this could be one or more of `requirements.txt`, `requirements_dev.txt`, `requirements/dev.txt`, `setup.py`, or `setup.cfg`. The latter two requiring parsing of files to get to what we want. For conda this will simply be `environment.yml`.
 - [ ] Make it so you can pass packages to create that will be installed into the virtual environment after creation (or during creation for conda). This is tricky to do with the current implementation as this would have to be in `pytoil project create` as an option like `--packages` or something and currently in Typer you can't pass a list to an option without doing something like this: `pytoil project create --venv virtualenv --packages package1 --packages package2 etc.`
 - [ ] Everything being under project feels clunkier than I thought it would. Would be good if we could instead do `pytoil checkout` `pytoil create` etc. rather than `pytoil project checkout`. If I remember right though, there are some issues doing this with Typer, everything to do with projects would have to live in `main.py` which might get messy.
 - [ ] Specify (in the config file) some packages to install in every environment pytoil creates. This is most useful for things like linters and formatters etc that you wan't in every project.
 
-### Medium Priority
+### Warm
 
 - [ ] Add support for poetry? Need to add entry to config file. If checkout project contains a `pyproject.toml` which references [tool.poetry] then use `poetry install` to create the environment.
 
-### Low Priority
+### Cold
 
 - [ ] Add a config check command that more closely inspects the config file and does some validation
 - [ ] Option to make a git repo on create, maybe a GitHub repo too and link them? Or is this better left to the gh cli?
+- [ ] Add pytoil remove --all option to completely clear projects directory

--- a/docs/img/coverage.svg
+++ b/docs/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">100%</text>
-        <text x="80" y="14">100%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">99%</text>
+        <text x="80" y="14">99%</text>
     </g>
 </svg>

--- a/pytoil/cli/main.py
+++ b/pytoil/cli/main.py
@@ -67,35 +67,43 @@ def init() -> None:
 
     # Make config file
     if not CONFIG_PATH.exists():
-        typer.secho("No config file found!\n", fg=typer.colors.YELLOW)
-        typer.echo("Creating fresh config file...\n")
-        CONFIG_PATH.touch()
-        default_config = Config()
-        default_config.write()
+        try:
+            typer.secho("No config file found!\n", fg=typer.colors.YELLOW)
+            typer.echo("Creating fresh config file...\n")
+            CONFIG_PATH.touch()
+            default_config = Config()
+            default_config.write()
 
-        username: str = typer.prompt("GitHub username")
-        token: str = typer.prompt("GitHub personal access token")
-        projects_dir: str = typer.prompt("Absolute path to your projects directory")
-        vscode: str = typer.prompt("Use VSCode to open projects with? [True|False]")
+            username: str = typer.prompt("GitHub username")
+            token: str = typer.prompt("GitHub personal access token")
+            projects_dir: str = typer.prompt("Absolute path to your projects directory")
+            vscode: str = typer.prompt("Use VSCode to open projects with? [True|False]")
 
-        projects_dir_path = pathlib.Path(projects_dir)
+            projects_dir_path = pathlib.Path(projects_dir)
 
-        if vscode.lower() == "true":
-            vscode_bool = True
-        elif vscode.lower() == "false":
-            vscode_bool = False
-        else:
-            raise typer.BadParameter("VSCode must be a boolean value")
+            if vscode.lower() == "true":
+                vscode_bool = True
+            elif vscode.lower() == "false":
+                vscode_bool = False
+            else:
+                raise typer.BadParameter("VSCode must be a boolean value")
 
-        user_config = Config(
-            username=username,
-            token=token,
-            projects_dir=projects_dir_path,
-            vscode=vscode_bool,
-        )
-        user_config.write()
+            user_config = Config(
+                username=username,
+                token=token,
+                projects_dir=projects_dir_path,
+                vscode=vscode_bool,
+            )
+            user_config.write()
 
-        typer.secho("Config written, you're good to go!", fg=typer.colors.GREEN)
+            typer.secho("Config written, you're good to go!", fg=typer.colors.GREEN)
+        except KeyboardInterrupt:
+            # TODO: How to test this?
+            # User pressed ctrl+c
+            # Delete any created config file and gracefully exit
+            typer.secho("Exiting config process...", fg=typer.colors.YELLOW)
+            CONFIG_PATH.unlink(missing_ok=True)
+            raise typer.Abort()
     else:
         try:
             config = Config.get()

--- a/pytoil/cli/project.py
+++ b/pytoil/cli/project.py
@@ -145,7 +145,7 @@ def create(
     if venv:
         if venv.value == venv.conda:
             typer.secho(
-                f"\nCreating conda environment for {project!r}.\n",
+                f"Creating conda environment for {project!r}.\n",
                 fg=typer.colors.BLUE,
                 bold=True,
             )
@@ -157,7 +157,7 @@ def create(
                 typer.echo(f"Using {conda_env.name!r} as the environment.")
             finally:
                 if config.vscode:
-                    typer.echo("Setting 'python.pythonPath' in VSCode workspace.\n")
+                    typer.echo("\nSetting 'python.pythonPath' in VSCode workspace.\n")
                     vscode.set_python_path(conda_env.executable)
                     typer.echo(f"Opening {project!r} in VSCode...")
                     vscode.open()
@@ -167,7 +167,7 @@ def create(
             # but it is: tests/cli/test_project_create.py
             # in several tests
             typer.secho(
-                f"\nCreating virtualenv for {project!r}.\n",
+                f"Creating virtualenv for {project!r}.\n",
                 fg=typer.colors.BLUE,
                 bold=True,
             )
@@ -181,14 +181,12 @@ def create(
             env.update_seeds()
 
             if config.vscode:
-                typer.echo("Setting 'python.pythonPath' in VSCode workspace.\n")
+                typer.echo("\nSetting 'python.pythonPath' in VSCode workspace.\n")
                 vscode.set_python_path(env.executable)
                 typer.echo(f"Opening {project!r} in VSCode...")
                 vscode.open()
     else:
-        typer.echo(
-            "\nVirtual environment not requested. Skipping environment creation."
-        )
+        typer.echo("Virtual environment not requested. Skipping environment creation.")
         if config.vscode:
             typer.echo(f"Opening {project!r} in VSCode...")
             vscode.open()


### PR DESCRIPTION
This commit fixes a small bug with `pytoil init` whereby if the user
hit `ctrl+c` during the interactive config session, it would leave
the config file intact but with the default config parameters of
"UNSET" for `username` and `token`.

This in turn is checked by the `Config.validate()` method in later
functions but this simply raises an `InvalidConfigError` and was
never intended to be displayed to the user. This meant that
the user would get an ugly error and traceback which didn't necessarily
point to the root problem.

pytoil init now handles this by catching the `KeyboardInterrupt` and
deleting any config file before gracefully exiting the program.

This means that when the user runs pytoil init again, it works as if
the first call was never aborted.
