### PR TITLE
Create can now init a git repo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.dev
 
 * NEW: `pytoil remove` now accepts list of projects to remove
+* NEW: `pytoil create` now initialises an empty git repo in non-cookiecutter projects
 
 ## 0.3.0
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,13 +7,13 @@ Below are a list of enhancements or fixes discovered during pre-release testing:
 ### Hot
 
 - [ ] Make it automatically install requirements if a file present. For setuptools this could be one or more of `requirements.txt`, `requirements_dev.txt`, `requirements/dev.txt`, `setup.py`, or `setup.cfg`. The latter two requiring parsing of files to get to what we want. For conda this will simply be `environment.yml`.
-- [ ] Change CLI to cleo for greater composability. Some of the functions are getting a bit too long and complex.
+- [ ] Change CLI to cleo for greater composability. Some of the functions are getting a bit too long and complex?
 
 ### Warm
 
 - [ ] Add support for poetry? Need to add entry to config file. If checkout project contains a `pyproject.toml` which references [tool.poetry] then use `poetry install` to create the environment.
 - [x] Make `pytoil remove` accept a list of local projects not just a single one
-- [ ] Make `pytoil create` initialise a new git repo, inspired by things like `cargo new` which does the same. Maybe configurable?
+- [x] Make `pytoil create` initialise a new git repo, inspired by things like `cargo new` which does the same. Maybe configurable?
 
 ### Cold
 

--- a/pytoil/cli/main.py
+++ b/pytoil/cli/main.py
@@ -155,14 +155,17 @@ def create(
             bold=True,
         )
         cookiecutter(template=cookie, output_dir=config.projects_dir)
+        # NOTE: no repo init here a some cookiecutters do this with a hook
+        # Most of mine do
     else:
         typer.secho(
             f"Creating project: {project!r} at '{repo.path}'.",
             fg=typer.colors.BLUE,
             bold=True,
         )
-        # Create an empty project dir
+        # Create an empty project dir & git repo
         repo.path.mkdir()
+        repo.init()
 
     if venv:
         if venv.value == venv.conda:


### PR DESCRIPTION
Added git repo initialisation to `pytoil create` for non
cookiecutter projects. Similar to things like `cargo new` that
do the same.

Doesn't do it for cookiecutter projects because cookiecutter can
run post generation hooks which most users utilise to run `git init`.
