### PR TITLE
Fix bug with repo info on non existent license.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.dev
+
+* BUG: Fix bug where `pytoil info` on a repo with no OSS license would cause an error. Not just displays `None` for `license`.
+
 ## 0.3.1
 
 * NEW: `pytoil remove` now accepts list of projects to remove

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,7 @@ Below are a list of enhancements or fixes discovered during pre-release testing:
 ### Hot
 
 - [ ] Make it automatically install requirements if a file present. For setuptools this could be one or more of `requirements.txt`, `requirements_dev.txt`, `requirements/dev.txt`, `setup.py`, or `setup.cfg`. The latter two requiring parsing of files to get to what we want. For conda this will simply be `environment.yml`.
+- [x] Fix bug where `pytoil info` on a repo without a license raises a nasty error rather than simply being `None`
 
 ### Warm
 

--- a/pytoil/api/api.py
+++ b/pytoil/api/api.py
@@ -181,13 +181,14 @@ class API:
         ]
 
         display_dict: Dict[str, Union[str, int]] = {
-            key: raw_repo_data.get(key, "Not Found") for key in keys_to_get
+            key: raw_repo_data.get(key, "Not found") for key in keys_to_get
         }
 
         # License is itself a dict
         # Couldn't be bothered doing some clever recursive thing for one key
-        display_dict["license"] = raw_repo_data.get("license", "Not Found").get(
-            "name", "Not Found"
-        )
+        if raw_repo_data["license"]:
+            display_dict["license"] = raw_repo_data.get("license", "Not Found").get(
+                "name", "Not Found"
+            )
 
         return display_dict


### PR DESCRIPTION
There was a bug with `pytoil info` where if a repo did not have
an OSS license, the program would raise an ugly error.

Now it simply checks whether it has a license and displays
`None` if not.
