### PR TITLE
Change default behaviour for `checkout`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.dev
+
+* NEW: `pytoil checkout` default behaviour changed to not create virtual environment. Now available through the `--venv` option bringing it in line with `pytoil new`
+
 ## 0.4.0
 
 * NEW: `pytoil create` changed to `pytoil new`

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 ## Tweaks & Fixes
 
 - [ ] Tweak how `Config` works such that every object/method that needs a `Config` can either have it's required arguments passed in directly into the method, or use the passed in `Config` object. This should eliminate a lot of mocking complexity in the tests and make sure we don't need to keep calling `config.get` everywhere that needs it which is IO expensive.
-- [ ] In `pytoil checkout` make the default behaviour not to try to detect and auto-create an environment, but only do so with a `--venv` boolean option if you want pytoil to try and guess the environment. This would bring `checkout` in line with `create` where a virtual environment is only created if requested with the `--venv` flag.
+- [x] In `pytoil checkout` make the default behaviour not to try to detect and auto-create an environment, but only do so with a `--venv` boolean option if you want pytoil to try and guess the environment. This would bring `checkout` in line with `new` where a virtual environment is only created if requested with the `--venv` flag.
 
 ## Essentials
 

--- a/docs/commands/project.md
+++ b/docs/commands/project.md
@@ -157,8 +157,6 @@ Opening 'my_github_project' in VSCode...
 If not, `checkout` will:
 
 * Clone it to your projects directory
-* Detect what type of project it is (conda or virtualenv)
-* Create the required virtual environment for you automatically
 * Open it for you (if you configure VSCode in [config])
 
 <div class="termy">
@@ -170,9 +168,6 @@ $ pytoil checkout my_github_project
 Project: 'my_github_project' found on GitHub! Cloning...
 // You might see some git clone output here
 
-Auto-creating correct virtual environment
-// Here you might see some conda or virtualenv stuff
-
 Opening 'my_github_project' in VSCode...
 ```
 
@@ -183,6 +178,29 @@ Opening 'my_github_project' in VSCode...
     When developing pytoil I was debating how to handle this. I use VSCode for everything but I know other people have different editor preferences. Initially I looked at using the `$EDITOR` environment variable but working out how best to launch a variety of possible editors from a CLI was tricky. Plus pytoil does things like alter workspace settings to point at the right virtual environment, and I only know how to do this with VSCode.
 
     PR's are very welcome though if you think you can introduce support for your preferred editor! :grin:
+
+If you pass the `--venv` option, `checkout` will also:
+
+* Try to detect what environment would work best for the project (conda or virtualenv)
+* Auto create this virtual environment and install any configured common packages
+* If you have VSCode configured, `pytoil` will also set your workspace `python.pythonPath`
+
+<div class="termy">
+
+```console
+// Some project thats on GitHub
+$ pytoil checkout my_github_project --venv
+
+Project: 'my_github_project' found on GitHub! Cloning...
+// You might see some git clone output here
+
+Auto-creating correct virtual environment
+// Here you might see some conda or virtualenv stuff
+
+Opening 'my_github_project' in VSCode...
+```
+
+</div>
 
 ## Remove
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -151,7 +151,6 @@ Resuming 'myproject'...
 
 // Will now either open that project if local
 // or clone it if not
-// Ensure virtual environments are set up etc.
 ```
 
 </div>


### PR DESCRIPTION
Brought `checkout` in line with `new` in that a virtual
environment is only created if specifically requested with the
`--venv` option.
