### PR TITLE
Remove `is_editable` from `repo.py`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,3 +106,7 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "toml.*"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+ignore_errors = true

--- a/pytoil/repo/repo.py
+++ b/pytoil/repo/repo.py
@@ -163,20 +163,6 @@ class Repo:
         """
         return self.file_exists("environment.yml")
 
-    def is_editable(self) -> bool:
-        """
-        Does the project support editable installs
-        for development
-
-        i.e. 'pip install -e .'
-
-        Only possible with a 'setup.py'.
-
-        Returns:
-            bool: True if editable, else False.
-        """
-        return self.file_exists("setup.py")
-
     def is_PEP517(self) -> bool:
         """
         Does the project comply with

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -364,28 +364,6 @@ def test_is_conda(repo_folder_with_random_existing_files, file, expect):
     "file, expect",
     [
         ("setup.cfg", False),
-        ("setup.py", True),
-        ("dingle.cfg", False),
-        ("dingle.py", False),
-        ("pyproject.toml", False),
-        ("environment.yml", False),
-    ],
-)
-def test_is_editable(repo_folder_with_random_existing_files, file, expect):
-
-    folder: Path = repo_folder_with_random_existing_files
-    repo = Repo(owner="me", name="test", local_path=folder)
-
-    # Add in the required file to trigger
-    folder.joinpath(file).touch()
-
-    assert repo.is_editable() is expect
-
-
-@pytest.mark.parametrize(
-    "file, expect",
-    [
-        ("setup.cfg", False),
         ("setup.py", False),
         ("dingle.cfg", False),
         ("dingle.py", False),


### PR DESCRIPTION
Removed the `is_editable` checking method as in recent versions of
pip, the presence of `setup.py` is no longer required for editable
installs.

Also made mypy ignore errors in the tests as strictly typing tests
especially with mocks involved is annoying.
