### PR TITLE
Add detection for flit and poetry build systems.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -110,8 +110,6 @@ jobs:
           python-version: 3.9
 
       - name: Install Dependencies
-        # Uses pypa build https://pypa-build.readthedocs.io/en/latest/
-        # For full PEP517/518 compliance
         run: |
           python3 -m pip install --upgrade pip setuptools wheel
           python3 -m pip install poetry

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,7 @@ Ideas for enhancements or fixes.
 - [ ] When batch pulling repos, do it in parallel? Wouldn't need threads or anything like that, just a series of calls to `subprocess.Popen` which spawns a subprocess but does not wait for it to complete like `subprocess.run` does. Therefore we could fire off all the `git clones` for each url and just report when they're all done. Probably have to do it in some sort of task queue with workers though incase someone has thousands of repos and it bricks the machine!
 - [ ] On `pytoil new --starter --venv` make it export a `requirement.txt` or `environment.yml`
 - [ ] If the repo passed to `pytoil checkout` is of the form `username/repo`, pytoil will first fork that repo to the user, then clone it as normal. This means pytoil can now be used to easily collaborate on open source stuff.
+- [ ] Automatically detect requirements. E.g. if project is checked out with `--venv` pytoil should look for things like `requirements.txt`, `requirements_dev.txt`, `setup.cfg`, `pyproject.toml` etc and see if it can parse requirements and install them.
 
 ## Fixes
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,6 +16,10 @@ nox.needs_version = ">=2021.6.6"
 ON_CI = bool(os.getenv("CI"))
 
 PROJECT_ROOT = Path(__file__).parent.resolve()
+PROJECT_SRC = PROJECT_ROOT / "pytoil"
+PROJECT_TESTS = PROJECT_ROOT / "tests"
+
+COVERAGE_BADGE = PROJECT_ROOT / "docs" / "img" / "coverage.svg"
 
 DEFAULT_PYTHON: str = "3.9"
 
@@ -121,7 +125,7 @@ def test(session: nox.Session) -> None:
     session.run("poetry", "install", "--no-dev", external=True, silent=True)
     poetry_install(session, *test_requirements)
 
-    session.run("pytest", "--cov=pytoil", "tests/")
+    session.run("pytest", f"--cov={PROJECT_SRC}", f"{PROJECT_TESTS}/")
     session.notify("coverage")
 
 
@@ -133,7 +137,7 @@ def coverage(session: nox.Session) -> None:
 
     coverage_requirements = SESSION_REQUIREMENTS.get("coverage", [""])
 
-    img_path = PROJECT_ROOT.joinpath("docs/img/coverage.svg")
+    img_path = COVERAGE_BADGE
 
     if not img_path.exists():
         img_path.parent.mkdir(parents=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Union
 
 import pytest
+import toml
 import yaml
 
 TESTDATA = Path(__file__).parent.joinpath("testdata")
@@ -294,5 +295,101 @@ def repo_folder_with_random_existing_files(tmp_path_factory):
     for file in files:
         # Create each file under the myrepo folder
         folder.joinpath(file).touch()
+
+    return folder
+
+
+@pytest.fixture
+def project_with_no_build_system(tmp_path_factory):
+    """
+    Returns a temporary directory containing a
+    pyproject.toml but this file does not specify
+    a build-system, which is bad.
+    """
+
+    # Create the folder and pyproject.toml file
+    folder: Path = tmp_path_factory.mktemp("myrepo")
+    pyproject_toml = folder.joinpath("pyproject.toml")
+    pyproject_toml.touch()
+
+    return folder
+
+
+@pytest.fixture
+def project_with_no_build_backend(tmp_path_factory):
+    """
+    Returns a temporary directory containing a
+    pyproject.toml.
+
+    This time we do write a 'build-system' but no
+    'build-backend'.
+    """
+
+    # Create the folder and pyproject.toml file
+    folder: Path = tmp_path_factory.mktemp("myrepo")
+    pyproject_toml = folder.joinpath("pyproject.toml")
+    pyproject_toml.touch()
+
+    # Create some fake build-system
+    build_system = {
+        "build-system": {
+            "requires": ["poetry-core>=1.0.0"],
+        },
+    }
+
+    with open(pyproject_toml, mode="w", encoding="utf-8") as f:
+        toml.dump(build_system, f)
+
+    return folder
+
+
+@pytest.fixture
+def fake_poetry_project(tmp_path_factory):
+    """
+    Returns a temporary directory containing a
+    valid poetry pyproject.toml file.
+    """
+
+    # Create the folder and pyproject.toml file
+    folder: Path = tmp_path_factory.mktemp("myrepo")
+    pyproject_toml = folder.joinpath("pyproject.toml")
+    pyproject_toml.touch()
+
+    # Create some fake poetry content
+    build_system = {
+        "build-system": {
+            "requires": ["poetry-core>=1.0.0"],
+            "build-backend": "poetry.core.masonry.api",
+        },
+    }
+
+    with open(pyproject_toml, mode="w", encoding="utf-8") as f:
+        toml.dump(build_system, f)
+
+    return folder
+
+
+@pytest.fixture
+def fake_flit_project(tmp_path_factory):
+    """
+    Returns a temporary directory containing a
+    valid flit pyproject.toml file.
+    """
+
+    # Create the folder and pyproject.toml file
+    folder: Path = tmp_path_factory.mktemp("myrepo")
+    pyproject_toml = folder.joinpath("pyproject.toml")
+    pyproject_toml.touch()
+
+    # Create some fake poetry content
+    build_system = {
+        "build-system": {
+            "requires": ["flit_core >=2,<4"],
+            "build-backend": "flit_core.buildapi",
+        },
+    }
+
+    with open(pyproject_toml, mode="w", encoding="utf-8") as f:
+        toml.dump(build_system, f)
 
     return folder

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -360,38 +360,74 @@ def test_is_conda(repo_folder_with_random_existing_files, file, expect):
     assert repo.is_conda() is expect
 
 
-@pytest.mark.parametrize(
-    "file, expect",
-    [
-        ("setup.cfg", False),
-        ("setup.py", False),
-        ("dingle.cfg", False),
-        ("dingle.py", False),
-        ("pyproject.toml", False),
-        ("environment.yml", False),
-    ],
-)
-def test_is_PEP517(repo_folder_with_random_existing_files, file, expect):
+def test_is_poetry_true_on_valid_poetry_project(fake_poetry_project):
 
-    folder: Path = repo_folder_with_random_existing_files
-    repo = Repo(owner="me", name="test", local_path=folder)
+    repo = Repo(owner="blah", name="test", local_path=fake_poetry_project)
 
-    # Add in the required file to trigger
-    folder.joinpath(file).touch()
-
-    # We haven't written a build system to the toml so should
-    # return False
-    assert repo.is_PEP517() is expect
+    assert repo.is_poetry() is True
 
 
-def test_is_PEP517_detects_build_system():
+def test_is_poetry_false_on_non_poetry_project(fake_flit_project):
 
-    # This project has a valid pyproject.toml
-    # let's use that!
-    this_project = Path(__file__).parent.parent.resolve()
-    repo = Repo(owner="FollowTheProcess", name="pytoil", local_path=this_project)
+    repo = Repo(owner="blah", name="test", local_path=fake_flit_project)
 
-    assert repo.is_PEP517() is True
+    assert repo.is_poetry() is False
+
+
+def test_is_poetry_false_if_no_pyproject_toml():
+
+    repo = Repo(owner="blah", name="test", local_path=Path("nowhere"))
+
+    assert repo.is_poetry() is False
+
+
+def test_is_poetry_false_if_no_build_system(project_with_no_build_system):
+
+    repo = Repo(owner="blah", name="test", local_path=project_with_no_build_system)
+
+    assert repo.is_poetry() is False
+
+
+def test_is_poetry_false_if_no_build_backend(project_with_no_build_backend):
+
+    repo = Repo(owner="blah", name="test", local_path=project_with_no_build_backend)
+
+    assert repo.is_poetry() is False
+
+
+def test_is_flit_true_on_valid_flit_project(fake_flit_project):
+
+    repo = Repo(owner="blah", name="test", local_path=fake_flit_project)
+
+    assert repo.is_flit() is True
+
+
+def test_is_flit_false_on_non_flit_project(fake_poetry_project):
+
+    repo = Repo(owner="blah", name="test", local_path=fake_poetry_project)
+
+    assert repo.is_flit() is False
+
+
+def test_is_flit_false_if_no_pyproject_toml():
+
+    repo = Repo(owner="blah", name="test", local_path=Path("nowhere"))
+
+    assert repo.is_flit() is False
+
+
+def test_is_flit_false_if_no_build_system(project_with_no_build_system):
+
+    repo = Repo(owner="blah", name="test", local_path=project_with_no_build_system)
+
+    assert repo.is_flit() is False
+
+
+def test_is_flit_false_if_no_build_backend(project_with_no_build_backend):
+
+    repo = Repo(owner="blah", name="test", local_path=project_with_no_build_backend)
+
+    assert repo.is_flit() is False
 
 
 def test_dispatch_env_correctly_identifies_conda(mocker: MockerFixture):


### PR DESCRIPTION
Added methods and test in repo that will check whether or not
the repo is a poetry or flit-backed package.

This is part of the move to automatically detect and install
project requirements on checkout --venv.
