### PR TITLE
feat: Add ability to fork a repo on checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Dev
+
+* NEW: `pytoil checkout` can now fork someone else's repo is "user/repo" pattern is passed as an argument
+
 ## 0.6.3
 
 * NEW: `pytoil config get` now prints the key in a nice colour too

--- a/docs/commands/checkout.md
+++ b/docs/commands/checkout.md
@@ -22,11 +22,17 @@ Usage: pytoil checkout [OPTIONS] PROJECT
   config file it will open it for you. If not, it will just tell you it
   already exists locally and where to find it.
 
-  If your project is on GitHub, pytoil will clone it for you and then open
-  it (or tell you where it cloned it if you dont have VSCode set up).
+  If your project is on your GitHub, pytoil will clone it for you and then
+  open it (or tell you where it cloned it if you dont have VSCode set up).
 
   Finally, if checkout can't find a match after searching locally and on
   GitHub, it will prompt you to use 'pytoil new' to create a new one.
+
+  If you pass the shorthand to someone elses repo e.g. 'someoneelse/repo'
+  pytoil will detect this and automatically create a fork of this repo for
+  you. Forking happens asynchronously so we can't clone your fork straight
+  away. Give it a few seconds then a 'pytoil checkout repo' will bring it
+  down as normal.
 
   You can also ask pytoil to automatically create a virtual environment on
   checkout with the '--venv/-v' flag. This only happens for projects pulled
@@ -42,6 +48,8 @@ Usage: pytoil checkout [OPTIONS] PROJECT
   $ pytoil checkout my_project
 
   $ pytoil checkout my_project --venv
+
+  $ pytoil checkout someoneelse/project
 
 Arguments:
   PROJECT  Name of the project to checkout.  [required]
@@ -97,6 +105,29 @@ Opening 'my_github_project' in VSCode...
     When developing pytoil I was debating how to handle this. I use VSCode for everything but I know other people have different editor preferences. Initially I looked at using the `$EDITOR` environment variable but working out how best to launch a variety of possible editors from a CLI was tricky. Plus pytoil does things like alter workspace settings to point at the right virtual environment, and I only know how to do this with VSCode.
 
     PR's are very welcome though if you think you can introduce support for your preferred editor! :grin:
+
+## Someone else's project
+
+A common workflow in open source is to fork someone elses project and then work on your fork. With `pytoil` this can be done in the same command! If you provide the shorthand repo path to `pytoil checkout` e.g. `someoneelse/repo`, `pytoil` will fork the repo for you!
+
+<div class="termy">
+
+```console
+// Someone else's project
+$ pytoil checkout someone/their_github_project
+
+Project: 'someone/their_github_project' belongs to 'someone'. Making you a fork.
+
+Done!
+Note: Forking happens asynchronously on GitHub which means it may not be available to clone right away
+```
+
+</div>
+
+!!! note
+
+    As it says in the command line above, `pytoil` can't clone your fork right away because it happens in the background on GitHub's end
+    which means when we get the `202: Accepted` response from the API, there's no guarantee that your fork exists yet. The best bet is to give it a few seconds and then try checking it out as normal :thumbsup:
 
 ## Automatically Create a Virtual Environment
 

--- a/pytoil/api/api.py
+++ b/pytoil/api/api.py
@@ -61,7 +61,7 @@ class API:
             pass with the request. Defaults to None.
 
         Returns:
-            Response: JSON Response dict
+            Response: JSON Response dict.
         """
 
         r = httpx.post(url=self.baseurl + endpoint, headers=self.headers, params=params)
@@ -70,6 +70,21 @@ class API:
         response: Response = r.json()
 
         return response
+
+    def create_fork(self, owner: str, repo: str) -> Response:
+        """
+        Create a fork of the specified repository for the authenticated
+        user.
+
+        Args:
+            owner (str): Owner of the repo to be forked.
+            repo (str): Name of the repo to be forked.
+
+        Returns:
+            Response: JSON Response dict.
+        """
+
+        return self.post(endpoint=f"repos/{owner}/{repo}/forks")
 
     def get_repo(self, repo: str) -> Response:
         """

--- a/pytoil/api/api.py
+++ b/pytoil/api/api.py
@@ -50,6 +50,27 @@ class API:
 
         return response
 
+    def post(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Response:
+        """
+        Generic authenticated POST request method, used to make a POST
+        to any valid GitHub REST v3 API endpoint.
+
+        Args:
+            endpoint (str): The endpoint to POST.
+            params (Optional[Dict[str, Any]], optional): Dictionary of query params to
+            pass with the request. Defaults to None.
+
+        Returns:
+            Response: JSON Response dict
+        """
+
+        r = httpx.post(url=self.baseurl + endpoint, headers=self.headers, params=params)
+        r.raise_for_status()
+
+        response: Response = r.json()
+
+        return response
+
     def get_repo(self, repo: str) -> Response:
         """
         Get a user's repo by name.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -60,6 +60,34 @@ def test_get_returns_correct_response(httpx_mock: HTTPXMock, fake_repos_response
     assert r == fake_repos_response
 
 
+@pytest.mark.parametrize("bad_status_code", [400, 401, 403, 404, 500, 504, 505])
+def test_post_raises_on_bad_status(httpx_mock: HTTPXMock, bad_status_code):
+
+    httpx_mock.add_response(
+        url="https://api.github.com/user/repos", status_code=bad_status_code
+    )
+
+    api = API(token="definitelynotatoken", username="me")
+
+    with pytest.raises(httpx.HTTPStatusError):
+        api.post("user/repos")
+
+
+def test_post_returns_correct_response(httpx_mock: HTTPXMock, fake_repos_response):
+
+    httpx_mock.add_response(
+        url="https://api.github.com/user/repos",
+        json=fake_repos_response,
+        status_code=200,
+    )
+
+    api = API(token="definitelynotatoken", username="me")
+
+    r = api.post("user/repos")
+
+    assert r == fake_repos_response
+
+
 def test_get_repo_returns_correct_response(httpx_mock: HTTPXMock, fake_repo_response):
 
     httpx_mock.add_response(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -174,3 +174,22 @@ def test_get_repo_info_correctly_handles_missing_license(httpx_mock: HTTPXMock):
     api = API(token="definitelynotatoken", username="me")
 
     assert api.get_repo_info(repo="repo")["license"] is None
+
+
+def test_create_fork(httpx_mock: HTTPXMock):
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/someone/project/forks",
+        json={
+            "some": "yes",
+            "fake": "info",
+        },
+        status_code=202,
+    )
+
+    api = API(token="definitelynotatoken", username="me")
+
+    assert api.create_fork(owner="someone", repo="project") == {
+        "some": "yes",
+        "fake": "info",
+    }


### PR DESCRIPTION
This PR adds basic functionality for forking a repo when using `pytoil checkout`.

To use this feature simply pass the shorthand repo path to `checkout` for example:

``` shell
pytoil checkout someoneelse/repo
```
