### PR TITLE
Remove unused dev dependencies from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ toml = "^0.10.2"
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"
 bump2version = "^1.0.1"
-pre-commit = "^2.13.0"
 flake8 = "^3.9.2"
 isort = "^5.8.0"
 nox = ">=2021.6.6"
@@ -103,7 +102,6 @@ pretty = true
 
 [[tool.mypy.overrides]]
 module = [
-    "dodo.*",
     "tests.*",
 ]
 ignore_errors = true


### PR DESCRIPTION
There were some lingering dev dependencies that are no longer used, trimmed them out in this PR 👍🏻 