### PR TITLE
Refactor pyproject.toml build tool checks in Repo

### DIFF
--- a/pytoil/repo/repo.py
+++ b/pytoil/repo/repo.py
@@ -173,12 +173,23 @@ class Repo:
         """
         return self.file_exists("environment.yml")
 
-    def is_poetry(self) -> bool:
+    def _specifies_build_tool(self, build_tool: str) -> bool:
         """
-        Does the project specify a poetry build_system.
+        Generalised method to check for a particular
+        build tool specification in pyproject.toml.
+
+        Does more than a naive search for `build_tool`, actually
+        checks the appropriate toml construction so if this
+        method returns True, caller can be confident that
+        the pyproject.toml is valid.
+
+        Args:
+            build_tool (str): The build tool to check for
+                e.g. 'flit', 'poetry'
 
         Returns:
-            bool: True if yes, else False
+            bool: True if pyproject.toml specifies
+                that build tool, else False.
         """
 
         # First check if it even has a pyproject.toml
@@ -187,19 +198,29 @@ class Repo:
 
         toml_dict = toml.load(self.local_path.joinpath("pyproject.toml"))
         build_system = toml_dict.get("build-system")
-        # No build system means no poetry
+        # No build system means no PEP517
         if not build_system:
             return False
 
         build_backend: str = build_system.get("build-backend")
         # No build backend means a bad toml file
-        # also no poetry
+        # also no PEP517
         if not build_backend:
             return False
 
         # Now we know the toml file is valid
-        # check if it specifies poetry
-        return "poetry" in build_backend.strip().lower()
+        # check if it specifies the build tool in question
+        return build_tool in build_backend.strip().lower()
+
+    def is_poetry(self) -> bool:
+        """
+        Does the project specify a poetry build_system.
+
+        Returns:
+            bool: True if yes, else False
+        """
+
+        return self._specifies_build_tool("poetry")
 
     def is_flit(self) -> bool:
         """
@@ -209,25 +230,7 @@ class Repo:
             bool: True if yes, else False
         """
 
-        # First check if it even has a pyproject.toml
-        if not self.has_pyproject_toml():
-            return False
-
-        toml_dict = toml.load(self.local_path.joinpath("pyproject.toml"))
-        build_system = toml_dict.get("build-system")
-        # No build system, no flit
-        if not build_system:
-            return False
-
-        build_backend: str = build_system.get("build-backend")
-        # No build backend means bad toml file
-        # also no flit
-        if not build_backend:
-            return False
-
-        # Now we know the toml file is valid
-        # check if it specifies flit
-        return "flit" in build_backend.strip().lower()
+        return self._specifies_build_tool("flit")
 
     def dispatch_env(self) -> Optional[Environment]:
         """


### PR DESCRIPTION
DRY up some duplicated code to do with checking if a `Repo`'s `pyproject.toml` specifies a build tool.