### PR TITLE
Remove macos from GHA to speed up CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: [3.8, 3.9]
 
     steps:


### PR DESCRIPTION
Remove macOS from GitHub Actions for a few reasons:

* I'm developing on a Mac so everything in CI is run on my machine first anyway
* macOS builds on GitHub Actions are far slower than Ubuntu
* It's been running macOS for a while and there has never been a difference between that and Ubuntu
* They are both broadly unix compatible so it's not too different an environment