### PR TITLE
Pull multiple repos concurrently

### DIFF
--- a/docs/commands/pull.md
+++ b/docs/commands/pull.md
@@ -24,6 +24,9 @@ Usage: pytoil pull [OPTIONS] [PROJECTS]...
   You can also use pull to batch clone multiple repos, even all of them ("--
   all/-a") if you're into that sorta thing.
 
+  If more than 1 repo is passed (or if "--all/-a" is used) pytoil will pull
+  the repos concurrently, speeding up the process.
+
   Any remote project that already exists locally will be skipped and none of
   your local projects are changed in any way. pytoil will only pull down
   those projects that don't already exist locally.
@@ -36,13 +39,13 @@ Usage: pytoil pull [OPTIONS] [PROJECTS]...
 
   Examples:
 
-    $ pytoil pull project1 project2 project3
+  $ pytoil pull project1 project2 project3
 
-    $ pytoil pull project1 project2 project3 --force
+  $ pytoil pull project1 project2 project3 --force
 
-    $ pytoil pull --all
+  $ pytoil pull --all
 
-    $ pytoil pull --all --force
+  $ pytoil pull --all --force
 
 Arguments:
   [PROJECTS]...  Name of the project(s) to pull down.
@@ -52,14 +55,13 @@ Options:
   -a, --all    Pull down all of your projects.
   --help       Show this message and exit.
 
-
 ```
 
 </div>
 
 ## All
 
-When you run `pytoil pull --all` pytoil will scan your projects directory and your GitHub repos to calculate what's missing locally and then go and grab the missing projects from GitHub one by one.
+When you run `pytoil pull --all` pytoil will scan your projects directory and your GitHub repos to calculate what's missing locally and then go and grab the required repos concurrently so it's as fast as possible (useful if you have a lot of repos!) :dash:
 
 <div class="termy">
 
@@ -68,9 +70,9 @@ $ pytoil pull --all
 
 # This will clone 7 repos. Are you sure you wish to proceed? [y/N]:$ y
 
-Cloning 'repo1'...
+Cloned 'repo1'...
 
-Cloning 'repo2'...
+Cloned 'repo2'...
 
 etc...
 ```
@@ -79,7 +81,7 @@ etc...
 
 !!! warning
 
-    If you have lots of GitHub repos this could take a while, you might be better off selecting specific repos to pull by using `pytoil pull [project(s)]`. More on that down here :point_down:
+    Even though this is done concurrently, if you have lots of GitHub repos (> 50 or so) this could still take a few seconds, you might be better off selecting specific repos to pull by using `pytoil pull [project(s)]`. More on that down here :point_down:
 
     However, it will prompt you telling you exactly how many repos it is going to clone and ask you to confirm! This confirmation can be disabled by using the `--force/-f` flag.
 
@@ -136,3 +138,7 @@ Aborted!
 ```
 
 </div>
+
+!!! note
+
+    If you pass more than 1 repo as an argument, it will also be cloned concurrently :dash:

--- a/pytoil/cli/checkout.py
+++ b/pytoil/cli/checkout.py
@@ -128,7 +128,9 @@ def checkout(
 
         elif repo.exists_remote(api=api):
             msg.info(f"{repo.name!r} found on GitHub. Cloning...", spaced=True)
-            git.clone(url=repo.clone_url, check=True, cwd=config.projects_dir)
+            git.clone(
+                url=repo.clone_url, check=True, cwd=config.projects_dir, silent=False
+            )
 
             env = repo.dispatch_env()
 
@@ -211,7 +213,7 @@ def fork_repo(
 
     # If we get here, the fork was a success
     msg.info(f"Cloning your fork: {config.username}/{name}.", spaced=True)
-    git.clone(url=fork.clone_url, cwd=config.projects_dir)
+    git.clone(url=fork.clone_url, cwd=config.projects_dir, silent=False)
 
     # Set upstream
     msg.info("Setting 'upstream' to original repo.", spaced=True)

--- a/pytoil/cli/pull.py
+++ b/pytoil/cli/pull.py
@@ -147,7 +147,7 @@ def pull_diff(
     n_diff = len(diff)
 
     if not force:
-        if n_diff <= 5:
+        if n_diff <= 3:
             # A managable length to display each one
             typer.confirm(
                 f"This will pull down {', '.join(diff)}. Are you sure?", abort=True

--- a/pytoil/cli/pull.py
+++ b/pytoil/cli/pull.py
@@ -5,6 +5,7 @@ Author: Tom Fleet
 Created: 18/06/2021
 """
 
+import concurrent.futures
 from typing import List, Set
 
 import httpx
@@ -53,6 +54,9 @@ def pull(
 
     You can also use pull to batch clone multiple repos, even all of them ("--all/-a")
     if you're into that sorta thing.
+
+    If more than 1 repo is passed (or if "--all/-a" is used) pytoil will pull
+    the repos concurrently, speeding up the process.
 
     Any remote project that already exists locally will be skipped and none of
     your local projects are changed in any way. pytoil will only pull down
@@ -140,8 +144,10 @@ def pull_diff(
     if not remotes:
         msg.warn("You don't have any remote projects to pull!", spaced=True, exits=1)
 
+    n_diff = len(diff)
+
     if not force:
-        if len(diff) <= 5:
+        if n_diff <= 5:
             # A managable length to display each one
             typer.confirm(
                 f"This will pull down {', '.join(diff)}. Are you sure?", abort=True
@@ -149,11 +155,27 @@ def pull_diff(
         else:
             # Too many to show to look nice, just show number
             typer.confirm(
-                f"This will pull down {len(diff)} projects. Are you sure?", abort=True
+                f"This will pull down {n_diff} projects. Are you sure?", abort=True
             )
 
     # If we get here, we're good to go
 
+    if n_diff < 2:
+        # Doesn't make sense to spin up a thread pool for 1 repo
+        _pull_diff_synchronously(diff=diff, config=config, git=Git())
+    else:
+        # Let's go concurrency baby!
+        _pull_diff_concurrently(diff=diff, config=config, git=Git())
+
+
+def _pull_diff_synchronously(diff: Set[str], config: Config, git: Git) -> None:
+    """
+    Helper function to pull the diff synchronously, i.e.
+    one repo at a time.
+
+    To be used when the user only wants 1 repo, as it doesn't make sense
+    to spin up a thread pool for 1.
+    """
     for project in diff:
         # Make a Repo object for each
         repo = Repo(
@@ -163,6 +185,55 @@ def pull_diff(
         )
 
         msg.info(f"Cloning {project!r}", spaced=True)
-        git.clone(url=repo.clone_url, cwd=config.projects_dir)
+        # Because we're cloning just one, makes sense to show clone output
+        git.clone(url=repo.clone_url, cwd=config.projects_dir, silent=False)
 
     msg.good("Done!", spaced=True)
+
+
+def _pull_diff_concurrently(diff: Set[str], config: Config, git: Git) -> None:
+    """
+    Helper function to pull the diff concurrently using a pool
+    of worker threads.
+
+    Useful when more than 1 repo as the cost of spinning up a thread
+    pool is easily outweighed by the average repo clone time.
+    """
+    # Create a task queue
+    to_clone: List[Repo] = []
+    for project in diff:
+        # Make a Repo object for each to access the attributes
+        repo = Repo(
+            owner=config.username,
+            name=project,
+            local_path=config.projects_dir.joinpath(project),
+        )
+        to_clone.append(repo)
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+
+        # Start the cloning and mark each future with it's clone url
+        # Set silent=True in git.clone to prevent weird output ordering
+        future_to_repo = {
+            executor.submit(
+                git.clone, url=repo.clone_url, cwd=config.projects_dir, silent=True
+            ): repo
+            for repo in to_clone
+        }
+
+        for future in concurrent.futures.as_completed(future_to_repo):
+
+            current = future_to_repo.get(future)
+            if not current:
+                # Hopefully absolutely no chance of this happening but I like
+                # to always handle the None case from .get
+                raise ValueError(f"Repo in task queue for future: {future!r} was None")
+
+            try:
+                # Gather the result
+                future.result()
+            except Exception as err:
+                # This should only be very odd things
+                msg.fail(f"Error cloning {current.name!r}", text=f"{err}")
+            else:
+                msg.good(f"Cloned {current.name!r}")

--- a/pytoil/git/git.py
+++ b/pytoil/git/git.py
@@ -45,7 +45,11 @@ class Git:
             )
 
     def run(
-        self, *args: str, check: bool = True, cwd: Path = defaults.PROJECTS_DIR
+        self,
+        *args: str,
+        check: bool = True,
+        cwd: Path = defaults.PROJECTS_DIR,
+        silent: bool = False,
     ) -> None:
         """
         Generic method to run `git` in a subprocess.
@@ -61,6 +65,9 @@ class Git:
             cwd (Path, optional): Working directory of the subprocess.
                 Defaults to defaults.PROJECTS_DIR.
 
+            silent (bool): Whether to suppress showing the clone output.
+                Defaults to False.
+
         Raises:
             subprocess.CalledProcessError: If the subprocess command fails.
         """
@@ -68,12 +75,18 @@ class Git:
         self.raise_for_git()
 
         try:
-            subprocess.run([f"{self.git}", *args], check=check, cwd=cwd)
+            subprocess.run(
+                [f"{self.git}", *args], check=check, cwd=cwd, capture_output=silent
+            )
         except subprocess.CalledProcessError:
             raise
 
     def clone(
-        self, url: str, check: bool = True, cwd: Path = defaults.PROJECTS_DIR
+        self,
+        url: str,
+        check: bool = True,
+        cwd: Path = defaults.PROJECTS_DIR,
+        silent: bool = True,
     ) -> None:
         """
         Convenience wrapper around `self.run` to clone a repo.
@@ -87,13 +100,16 @@ class Git:
             cwd (Path, optional): Working directory of the subprocess.
                 Defaults to defaults.PROJECTS_DIR.
 
+            silent (bool): Whether to suppress showing the clone output.
+                Defaults to True.
+
         Raises:
             subprocess.CalledProcessError: If the subprocess command fails.
         """
 
-        self.run("clone", url, check=check, cwd=cwd)
+        self.run("clone", url, check=check, cwd=cwd, silent=silent)
 
-    def init(self, path: Path, check: bool = True) -> None:
+    def init(self, path: Path, check: bool = True, silent: bool = False) -> None:
         """
         Convenience wrapper around `self.run` to initialise a repo.
 
@@ -104,14 +120,22 @@ class Git:
             check (bool, optional): Raise CalledProcessError on failure.
                 Defaults to True.
 
+            silent (bool): Whether to suppress showing the clone output.
+                Defaults to False.
+
         Raises:
             subprocess.CalledProcessError: If the subprocess command fails.
         """
 
-        self.run("init", check=check, cwd=path)
+        self.run("init", check=check, cwd=path, silent=silent)
 
     def set_upstream(
-        self, owner: str, repo: str, path: Path, check: bool = True
+        self,
+        owner: str,
+        repo: str,
+        path: Path,
+        check: bool = True,
+        silent: bool = False,
     ) -> None:
         """
         Sets the upstream repo for a local repo, e.g. on a cloned fork.
@@ -127,9 +151,17 @@ class Git:
                 repo is.
             check (bool, optional): Raise CalledProcessError on failure.
                 Defaults to True.
+            silent (bool): Whether to suppress showing the clone output.
+            Defaults to True.
         """
         base_url = "https://github.com"
         constructed_upstream = f"{base_url}/{owner}/{repo}.git"
         self.run(
-            "remote", "add", "upstream", constructed_upstream, check=check, cwd=path
+            "remote",
+            "add",
+            "upstream",
+            constructed_upstream,
+            check=check,
+            cwd=path,
+            silent=silent,
         )

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -76,6 +76,7 @@ def test_run_passes_correct_command_to_subprocess(mocker: MockerFixture):
         ],
         cwd=Path("some/dir"),
         check=True,
+        capture_output=False,
     )
 
 
@@ -103,12 +104,18 @@ def test_clone_passes_correct_command_to_subprocess(mocker: MockerFixture):
     # Mock the subprocess of calling git
     mock_subprocess = mocker.patch("pytoil.git.git.subprocess.run", autospec=True)
 
-    git.clone(url="https://testhub.com/fake/repo.git", check=True, cwd=Path("some/dir"))
+    git.clone(
+        url="https://testhub.com/fake/repo.git",
+        check=True,
+        cwd=Path("some/dir"),
+        silent=True,
+    )
 
     mock_subprocess.assert_called_once_with(
         ["testgit", "clone", "https://testhub.com/fake/repo.git"],
         cwd=Path("some/dir"),
         check=True,
+        capture_output=True,
     )
 
 
@@ -127,6 +134,7 @@ def test_init_passes_correct_command_to_subprocess(mocker: MockerFixture):
         ["testgit", "init"],
         cwd=Path("some/dir/project"),
         check=True,
+        capture_output=False,
     )
 
 
@@ -150,4 +158,5 @@ def test_set_upstream_passes_correct_command_to_subprocess(mocker: MockerFixture
         ],
         check=True,
         cwd=Path("some/dir/project"),
+        capture_output=False,
     )


### PR DESCRIPTION
This PR implements pulling multiple repos via `pytoil pull <repos>` or `pytoil pull --all` concurrently
using a pool of worker threads and a task queue.

The rest of the functionality in `pytoil pull` is unchanged apart from having to silence
the output of the `git clone` subprocess when pulling concurrently due to synchronisation issues.

When passing only a single repo, this is cloned synchronously and normal clone output is shown to the user.

When pulling concurrently, only a success message is shown for each successful pull.

Closes #149 
