### PR TITLE
Checkout --venv on local repo now explicitly states venv is ignored

### DIFF
--- a/pytoil/cli/checkout.py
+++ b/pytoil/cli/checkout.py
@@ -124,6 +124,11 @@ def checkout(
         if repo.exists_local():
             # No environment or git stuff here, chances are if it exists locally
             # user has already done all this stuff
+            if venv:
+                typer.secho(
+                    "Note: '--venv' is ignored for local projects.",
+                    fg=typer.colors.YELLOW,
+                )
             checkout_local(repo=repo, code=code, config=config)
 
         elif repo.exists_remote(api=api):


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Title above -->

#### Description

When using `pytoil checkout <local_project> --venv` the virtual environment stuff was always ignored as local projects
often are already set up.

This PR implements an explicit info log to the user that this is the case.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Improves clarity and user experience.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
<!-- If you ran a nox session for example -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

#### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
