### PR TITLE
Add support for setting common_packages at the command line

### DIFF
--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -80,14 +80,6 @@ Config changed successfully!
 
     Pytoil uses [pydantic] under the hood to ensure the types of the values (e.g. bool, str, pathlib.Path etc.) are all handled properly so you basically can't go wrong!
 
-!!! warning
-
-    The only config key you can't currently set via the command line is `common_packages`. This is to do with the way shells and CLI apps handle lists and I don't see an easy way to solve it!
-
-    If you want to change this config setting, you will have to do it in the config file itself unfortunately :unamused:
-
-    Luckily, this tends to be a "fire and forget" setting, typically used for linters and formatters common to all python projects so you won't have to change it much!
-
 ## Show
 
 `show` is just a handy way of seeing what the current config is without having to go to the config file!


### PR DESCRIPTION
- Add support for setting common packages via the command line
- Drop common packages command line note from docs

<!-- Provide a brief summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
<!-- If you ran a nox session for example -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**

#### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
