### PR TITLE
Fix some conda tests from incorrectly failing when conda is not installed

### DIFF
--- a/tests/environments/test_conda.py
+++ b/tests/environments/test_conda.py
@@ -241,6 +241,13 @@ def test_create_from_yml_correctly_calls_subprocess(
         return_value=Path("/Users/testyconda3/envs"),
     )
 
+    # Ensure it doesn't raise if conda doesn't exist
+    mocker.patch(
+        "pytoil.environments.conda.Conda.raise_for_conda",
+        autospec=True,
+        return_value=None,
+    )
+
     expected_cmd: List[str] = [
         "conda",
         "env",
@@ -285,6 +292,13 @@ def test_create_from_yml_raises_if_env_already_exists(
 
     mocker.patch("pytoil.environments.Conda.exists", autospec=True, return_value=True)
 
+    # Ensure it doesn't raise if conda doesn't exist
+    mocker.patch(
+        "pytoil.environments.conda.Conda.raise_for_conda",
+        autospec=True,
+        return_value=None,
+    )
+
     with pytest.raises(EnvironmentAlreadyExistsError):
         Conda.create_from_yml(project_path=temp_environment_yml.parent)
 
@@ -304,6 +318,13 @@ def test_create_from_yml_raises_on_subprocess_error(
         "pytoil.environments.conda.Conda.get_envs_dir",
         autospec=True,
         return_value=Path("/Users/testyconda3/envs"),
+    )
+
+    # Ensure it doesn't raise if conda doesn't exist
+    mocker.patch(
+        "pytoil.environments.conda.Conda.raise_for_conda",
+        autospec=True,
+        return_value=None,
     )
 
     with pytest.raises(subprocess.CalledProcessError):


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
<!-- If you ran a nox session for example -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**

#### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
