### PR TITLE
Add support for using mamba

### DIFF
--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -50,18 +50,18 @@ vscode: True
 
 ```console
 $ pytoil config show
-                                                               
-               Key   Value                                     
- ───────────────────────────────────────────────────────────── 
-     projects_dir:   /Users/tomfleet/Development               
-            token:   lknskjb983e7g23hb8  
-         username:   FollowTheProcess                          
-           vscode:   True                                      
-         code_bin:   code-insiders                             
-        conda_bin:   mamba                                     
-  common_packages:   ['black', 'mypy', 'isort', 'flake8']      
-    cache_timeout:   120                                       
-              git:   True                                      
+
+               Key   Value
+ ─────────────────────────────────────────────────────────────
+     projects_dir:   /Users/tomfleet/Development
+            token:   lknskjb983e7g23hb8
+         username:   FollowTheProcess
+           vscode:   True
+         code_bin:   code-insiders
+        conda_bin:   mamba
+  common_packages:   ['black', 'mypy', 'isort', 'flake8']
+    cache_timeout:   120
+              git:   True
 ```
 
 </div>

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -50,16 +50,18 @@ vscode: True
 
 ```console
 $ pytoil config show
-
-               Key   Value
- ─────────────────────────────────────────────────────────────
-     projects_dir:   /Users/tomfleet/Development
-            token:   jsbsljas72j2kx0ub
-         username:   FollowTheProcess
-           vscode:   True
-         code_bin:   code
-  common_packages:   ['black', 'mypy', 'isort', 'flake8']
-              git:   True
+                                                               
+               Key   Value                                     
+ ───────────────────────────────────────────────────────────── 
+     projects_dir:   /Users/tomfleet/Development               
+            token:   lknskjb983e7g23hb8  
+         username:   FollowTheProcess                          
+           vscode:   True                                      
+         code_bin:   code-insiders                             
+        conda_bin:   mamba                                     
+  common_packages:   ['black', 'mypy', 'isort', 'flake8']      
+    cache_timeout:   120                                       
+              git:   True                                      
 ```
 
 </div>
@@ -117,10 +119,19 @@ $ pytoil config explain
 
     The name of the VSCode binary ('code' or 'code-insiders')
 
+- conda_bin (str)
+
+    The name of the conda binary ('conda' or 'mamba')
+
 - common_packages (List[str])
 
     A list of python package names to inject into every virtual environment pytoil creates
     (e.g. linters, formatters and other dev dependencies).
+
+- cache_timeout (int)
+
+    The number of seconds pytoil keeps a cache of GitHub API requests for. Subsequent API calls
+    within this window will be served from cache not from the API.
 
 - git (bool)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -22,6 +22,7 @@ There are also some *optional* configurations you can tweak:
 |  `projects_dir`   |                                     Where you keep your projects                                      | `$HOME/Development` |
 |     `vscode`      |                           Whether you want pytoil to open things in VSCode                            |        False        |
 |     `code_bin`    |                           The name of the VSCode binary (code or code-insiders)                       |        `code`       |
+|     `conda_bin`   |                           The name of the conda binary (conda or mamba)                               |        `conda`      |
 | `common_packages` | List of packages you want pytoil to inject in every environment it creates (linters, formatters etc.) |       `None`        |
 | `cache_timeout`   | Maximum duration you want pytoil to keep a cache of API responses for (seconds)                       |       120           |
 |   `git`           |        Whether you want pytoil to initialise and commit a git repo when it makes a fresh project      |        True         |
@@ -73,6 +74,7 @@ When you open the config file, it will look something like this:
 [pytoil]
 cache_timeout = 120
 code_bin = "code"
+conda_bin = "conda"
 common_packages = []
 git = true
 projects_dir = "/Users/you/Development"
@@ -95,6 +97,7 @@ So as an example, your filled out config file might look like this:
 [pytoil]
 cache_timeout = 500
 code_bin = "code"
+conda_bin = "mamba"
 common_packages = ["black", "mypy", "isort", "flake8"]
 git = true
 projects_dir = "/Users/you/Development"

--- a/pytoil/cli/checkout.py
+++ b/pytoil/cli/checkout.py
@@ -193,7 +193,7 @@ async def checkout_fork(
     await git.set_upstream(owner=owner, repo=name, cwd=fork.local_path)
 
     # Automatic environment detection
-    env = await fork.dispatch_env()
+    env = await fork.dispatch_env(config=config)
 
     # Special code instance because the argument 'project' will be the user/repo pattern
     code = VSCode(root=config.projects_dir.joinpath(name), code=config.code_bin)
@@ -264,7 +264,7 @@ async def checkout_remote(
     # Only cloning 1 repo so makes sense to show output
     await git.clone(url=repo.clone_url, cwd=config.projects_dir, silent=False)
 
-    env = await repo.dispatch_env()
+    env = await repo.dispatch_env(config=config)
 
     if venv:
         await handle_venv_creation(env=env, config=config, code=code)

--- a/pytoil/cli/config.py
+++ b/pytoil/cli/config.py
@@ -82,7 +82,7 @@ async def edit(config: Config) -> None:
 
     $ pytoil config edit
     """
-    click.edit(filename=str(defaults.CONFIG_FILE))
+    click.launch(str(defaults.CONFIG_FILE), wait=False)
 
 
 @config.command()

--- a/pytoil/cli/new.py
+++ b/pytoil/cli/new.py
@@ -230,6 +230,8 @@ async def new(  # noqa: C901
             await env.create(packages=to_install, silent=True)
 
     elif venv == "conda":
+        # Note, conda installs take longer so by default we don't hide the output
+        # like we do for normal python environments
         printer.info(f"Creating conda environment for {repo.name}")
         if to_install:
             printer.note(f"Including {', '.join(to_install)}")

--- a/pytoil/cli/new.py
+++ b/pytoil/cli/new.py
@@ -234,7 +234,9 @@ async def new(  # noqa: C901
         if to_install:
             printer.note(f"Including {', '.join(to_install)}")
 
-        conda_env = Conda(root=repo.local_path, environment_name=repo.name)
+        conda_env = Conda(
+            root=repo.local_path, environment_name=repo.name, conda=config.conda_bin
+        )
         try:
             await conda_env.create(packages=to_install)
         except EnvironmentAlreadyExistsError:

--- a/pytoil/cli/root.py
+++ b/pytoil/cli/root.py
@@ -113,7 +113,7 @@ async def main(ctx: click.Context) -> None:
 
             which_vscode: str = await questionary.select(
                 "Which version of VSCode do you use?",
-                choices=["stable", "insiders"],
+                choices=("stable", "insiders"),
                 default="stable",
             ).ask_async()
 
@@ -125,12 +125,19 @@ async def main(ctx: click.Context) -> None:
             "Make git repos when creating new projects?", default=True, auto_enter=False
         ).ask_async()
 
+        conda_bin: str = await questionary.select(
+            "Use conda or mamba for conda environments?",
+            choices=("conda", "mamba"),
+            default="conda",
+        ).ask_async()
+
         config = Config(
             projects_dir=Path(projects_dir).resolve(),
             token=token,
             username=username,
             vscode=vscode,
             code_bin=code_bin,
+            conda_bin=conda_bin,
             git=git,
         )
 

--- a/pytoil/config/config.py
+++ b/pytoil/config/config.py
@@ -32,6 +32,7 @@ class ConfigDict(TypedDict):
     username: str
     vscode: bool
     code_bin: str
+    conda_bin: str
     common_packages: list[str]
     cache_timeout: int
     git: bool
@@ -43,6 +44,7 @@ class Config(BaseModel):
     username: str = defaults.USERNAME
     vscode: bool = defaults.VSCODE
     code_bin: str = defaults.CODE_BIN
+    conda_bin: str = defaults.CONDA_BIN
     common_packages: list[str] = defaults.COMMON_PACKAGES
     cache_timeout: int = defaults.CACHE_TIMEOUT_SECS
     git: bool = defaults.GIT
@@ -101,6 +103,7 @@ class Config(BaseModel):
             "username": self.username,
             "vscode": self.vscode,
             "code_bin": self.code_bin,
+            "conda_bin": self.conda_bin,
             "common_packages": self.common_packages,
             "cache_timeout": self.cache_timeout,
             "git": self.git,

--- a/pytoil/config/defaults.py
+++ b/pytoil/config/defaults.py
@@ -19,6 +19,9 @@ CONFIG_KEYS: set[str] = {
     "token",
     "username",
     "vscode",
+    "code_bin",
+    "conda_bin",
+    "cache_timeout",
     "common_packages",
     "git",
 }
@@ -37,6 +40,7 @@ TOKEN: str = os.getenv("GITHUB_TOKEN", "")
 USERNAME: str = ""
 VSCODE: bool = False
 CODE_BIN: str = "code"
+CONDA_BIN: str = "conda"
 COMMON_PACKAGES: list[str] = []
 GIT: bool = True
 
@@ -71,6 +75,16 @@ Whether you want pytoil to open projects up using VSCode. This will happen on 'n
 
 The name of the VSCode binary. Will differ depending on version installed. Either "code" (default)
 or "code-insiders"
+
+## conda_bin *(str)*
+
+The name of the binary to use when performing conda operations. Either "conda" (default)
+or "mamba"
+
+# cache_timeout *(int)*
+
+The number of seconds pytoil keeps a cache of GitHub API requests for. Subsequent API calls
+within this window will be served from cache not from the API.
 
 ## common_packages *(List[str])*
 

--- a/pytoil/environments/conda.py
+++ b/pytoil/environments/conda.py
@@ -183,13 +183,16 @@ class Conda:
         await proc.wait()
 
     @staticmethod
-    async def create_from_yml(project_path: Path, silent: bool = False) -> None:
+    async def create_from_yml(
+        project_path: Path, conda: str, silent: bool = False
+    ) -> None:
         """
         Creates a conda environment from the `environment.yml` contained
         in the root `project_path`
 
         Args:
             project_path (Path): Filepath to the project root.
+            conda (str): The conda binary.
             silent (bool, optional): Whether to discard or display output.
                 Defaults to False.
 
@@ -199,7 +202,7 @@ class Conda:
                 exists on the system.
         """
 
-        if not shutil.which("conda"):
+        if not shutil.which(conda):
             raise CondaNotInstalledError
 
         # Ensure we have a fully resolved project path
@@ -226,7 +229,7 @@ class Conda:
 
         # Can't use self.conda here as static method so just rely on $PATH
         proc = await asyncio.create_subprocess_exec(
-            "conda",
+            conda,
             "env",
             "create",
             "--file",
@@ -325,4 +328,9 @@ class Conda:
             silent (bool, optional): Whether to discard or display output.
                 Defaults to False.
         """
-        await self.create_from_yml(project_path=self.project_path, silent=silent)
+        if not self.conda:
+            raise CondaNotInstalledError
+
+        await self.create_from_yml(
+            project_path=self.project_path, conda=self.conda, silent=silent
+        )

--- a/pytoil/repo/repo.py
+++ b/pytoil/repo/repo.py
@@ -19,6 +19,7 @@ import humanize
 import tomlkit
 
 from pytoil.api import API
+from pytoil.config import Config
 from pytoil.environments import Conda, Environment, Flit, Poetry, Requirements, Venv
 from pytoil.exceptions import RepoNotFoundError
 
@@ -276,7 +277,7 @@ class Repo:
         """
         return await self._specifies_build_tool("flit")
 
-    async def dispatch_env(self) -> Environment | None:
+    async def dispatch_env(self, config: Config) -> Environment | None:
         """
         Returns the correct environment object for the calling `Repo`,
         or `None` if it cannot detect the environment.
@@ -305,7 +306,9 @@ class Repo:
         conda, requirements, setuptools, poetry, flit = exists
 
         if conda:
-            return Conda(root=self.local_path, environment_name=self.name)
+            return Conda(
+                root=self.local_path, environment_name=self.name, conda=config.conda_bin
+            )
         elif requirements:
             return Requirements(root=self.local_path)
         elif setuptools:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,7 @@ def test_config_init_defaults():
     assert config.username == defaults.USERNAME
     assert config.vscode == defaults.VSCODE
     assert config.code_bin == defaults.CODE_BIN
+    assert config.conda_bin == defaults.CONDA_BIN
     assert config.common_packages == defaults.COMMON_PACKAGES
     assert config.cache_timeout == defaults.CACHE_TIMEOUT_SECS
     assert config.git == defaults.GIT
@@ -34,6 +35,7 @@ def test_config_init_passed():
         username="me",
         vscode=True,
         code_bin="code-insiders",
+        conda_bin="mamba",
         common_packages=["black", "mypy", "flake8"],
         cache_timeout=500,
         git=False,
@@ -44,6 +46,7 @@ def test_config_init_passed():
     assert config.username == "me"
     assert config.vscode is True
     assert config.code_bin == "code-insiders"
+    assert config.conda_bin == "mamba"
     assert config.common_packages == ["black", "mypy", "flake8"]
     assert config.cache_timeout == 500
     assert config.git is False
@@ -58,6 +61,7 @@ def test_config_helper():
     assert config.username == "This your GitHub username"
     assert config.vscode == defaults.VSCODE
     assert config.code_bin == defaults.CODE_BIN
+    assert config.conda_bin == defaults.CONDA_BIN
     assert config.common_packages == defaults.COMMON_PACKAGES
     assert config.git == defaults.GIT
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -6,6 +6,7 @@ from pytest_httpx import HTTPXMock
 from pytest_mock import MockerFixture
 
 from pytoil.api import API
+from pytoil.config import Config
 from pytoil.environments import Conda, Flit, Poetry, Requirements, Venv
 from pytoil.repo import Repo
 
@@ -277,7 +278,7 @@ async def test_dispatch_env_correctly_identifies_conda(mocker: MockerFixture):
 
     repo = Repo(name="test", owner="me", local_path=Path("somewhere"))
 
-    env = await repo.dispatch_env()
+    env = await repo.dispatch_env(config=Config())
 
     assert isinstance(env, Conda)
 
@@ -289,7 +290,7 @@ async def test_dispatch_env_correctly_identifies_requirements_txt(
 
     repo = Repo(name="test", owner="me", local_path=requirements_project)
 
-    env = await repo.dispatch_env()
+    env = await repo.dispatch_env(config=Config())
 
     assert isinstance(env, Requirements)
 
@@ -301,7 +302,7 @@ async def test_dispatch_env_correctly_identifies_requirements_dev_txt(
 
     repo = Repo(name="test", owner="me", local_path=requirements_dev_project)
 
-    env = await repo.dispatch_env()
+    env = await repo.dispatch_env(config=Config())
 
     assert isinstance(env, Requirements)
 
@@ -315,7 +316,7 @@ async def test_dispatch_env_correctly_identifies_setuptools(mocker: MockerFixtur
 
     repo = Repo(name="test", owner="me", local_path=Path("somewhere"))
 
-    env = await repo.dispatch_env()
+    env = await repo.dispatch_env(config=Config())
 
     assert isinstance(env, Venv)
 
@@ -324,7 +325,7 @@ async def test_dispatch_env_correctly_identifies_setuptools(mocker: MockerFixtur
 async def test_dispatch_env_correctly_identifies_poetry(fake_poetry_project: Path):
     repo = Repo(name="test", owner="me", local_path=fake_poetry_project)
 
-    env = await repo.dispatch_env()
+    env = await repo.dispatch_env(config=Config())
 
     assert isinstance(env, Poetry)
 
@@ -334,7 +335,7 @@ async def test_dispatch_env_correctly_identifies_flit(fake_flit_project: Path):
 
     repo = Repo(name="test", owner="me", local_path=fake_flit_project)
 
-    env = await repo.dispatch_env()
+    env = await repo.dispatch_env(config=Config())
 
     assert isinstance(env, Flit)
 
@@ -348,6 +349,6 @@ async def test_dispatch_env_returns_none_if_it_cant_detect(mocker: MockerFixture
 
     repo = Repo(name="test", owner="me", local_path=Path("somewhere"))
 
-    env = await repo.dispatch_env()
+    env = await repo.dispatch_env(config=Config())
 
     assert env is None


### PR DESCRIPTION
- Add conda bin key and default to config
- Add conda bin to interactive config setup
- Hook the config conda bin up to the conda installers
- Hook the config conda bin up to the CLI
- Change click.edit to click.launch in config edit
- Put explanatory comment as to why conda create is not silent by default
- Add documentation around configuring mamba

<!-- Provide a brief summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->

This PR adds support for configuring pytoil to use mamba when creating conda environments as well as supporting
documentation and help.

Added a new config key `conda_bin` which accepts 'conda' or 'mamba' which is now propegated down
to all conda environment handling.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #551

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
<!-- If you ran a nox session for example -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**

#### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation if needed.
- [x] I have updated the tests if needed.
